### PR TITLE
fix: nuuuuunez

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ fn scan_primitive(sentence: &str) -> Result<(usize, Word), JError> {
             }
         }
     }
-    Ok((l, str_to_primitive(&sentence[0..=l])?))
+    Ok((l, str_to_primitive(&sentence.chars().take(l + 1).collect::<String>())?))
 }
 
 fn str_to_primitive(sentence: &str) -> Result<Word, JError> {
@@ -547,4 +547,3 @@ fn v_times<'x, 'y>(x: Option<&'x Word>, y: &'y Word) -> Result<Word, JError> {
         }
     }
 }
-

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -2,11 +2,10 @@ use jr::JArray::*;
 use jr::{VerbImpl, Word};
 use ndarray::prelude::*;
 
-// TODO support unicode properly
-//#[test]
-//fn test_scan_nunez() {
-//let _ =jr::scan("й");
-//}
+#[test]
+fn test_scan_nunez() {
+    let _ = jr::scan("й");
+}
 
 #[test]
 fn invalid_prime() {


### PR DESCRIPTION
"Slice" the `chars()` iterator (using `take`) instead of slicing the underlying bytes, unfortunately there's no nice `..=` syntax here I don't think. This appears to be the only place we do this.

Can now survive fuzzing 6 (!) non-ascii bytes.