### PR TITLE
feat: wrapper type for Char?

### DIFF
--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -4,6 +4,8 @@ pub use crate::verbs::*;
 use ndarray::prelude::*;
 use thiserror::Error;
 
+use crate::char_array::Char;
+
 // TODO: https://code.jsoftware.com/wiki/Vocabulary/ErrorMessages
 #[derive(Debug, Error)]
 pub enum JError {
@@ -107,7 +109,7 @@ pub enum Word {
 #[derive(Clone, Debug, PartialEq)]
 pub enum JArray {
     BoolArray { a: ArrayD<u8> },
-    CharArray { a: ArrayD<char> },
+    CharArray { a: ArrayD<Char> },
     IntArray { a: ArrayD<i64> },
     ExtIntArray { a: ArrayD<i128> }, // TODO: num::bigint::BigInt
     //RationalArray { ... }, // TODO: num::rational::Rational64
@@ -145,7 +147,9 @@ macro_rules! apply_array_homo {
             JArray::FloatArray { .. } => JArray::FloatArray {
                 a: $func(&homo_array!(JArray::FloatArray, $arr.iter()))?,
             },
-            JArray::CharArray { .. } => todo!("char isn't Zero, so we can't create an array of it"),
+            JArray::CharArray { .. } => JArray::CharArray {
+                a: $func(&homo_array!(JArray::CharArray, $arr.iter()))?,
+            },
         }
     };
 }
@@ -225,7 +229,10 @@ pub fn int_array(v: impl Arrayable<i64>) -> Result<Word, JError> {
 pub fn char_array(x: impl AsRef<str>) -> Result<Word, JError> {
     let x = x.as_ref();
     Ok(Word::Noun(JArray::CharArray {
-        a: ArrayD::from_shape_vec(IxDyn(&[x.chars().count()]), x.chars().collect())?,
+        a: ArrayD::from_shape_vec(
+            IxDyn(&[x.chars().count()]),
+            x.chars().map(Char::new).collect(),
+        )?,
     }))
 }
 

--- a/src/char_array.rs
+++ b/src/char_array.rs
@@ -1,0 +1,28 @@
+use num_traits::Zero;
+use std::ops::Add;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Char(char);
+
+impl Char {
+    pub fn new(c: char) -> Self {
+        Char(c)
+    }
+}
+
+impl Add<Self> for Char {
+    type Output = Char;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Char((self.0 as u8 + rhs.0 as u8) as char)
+    }
+}
+
+impl Zero for Char {
+    fn zero() -> Self {
+        Char('\0')
+    }
+    fn is_zero(&self) -> bool {
+        self.0 == '\0'
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod arrays;
+mod char_array;
 pub mod eval;
 pub mod modifiers;
 pub mod scan;
@@ -11,6 +12,8 @@ pub use crate::eval::*;
 pub use crate::modifiers::*;
 pub use crate::scan::*;
 pub use crate::verbs::*;
+
+pub use char_array::Char;
 
 fn primitive_verbs() -> HashMap<&'static str, VerbImpl> {
     HashMap::from([

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -1,6 +1,6 @@
 use jr::verbs::reshape;
 use jr::JArray::*;
-use jr::{collect_nouns, JError, ModifierImpl, VerbImpl, Word};
+use jr::{collect_nouns, Char, ModifierImpl, VerbImpl, Word};
 use ndarray::prelude::*;
 
 #[test]
@@ -248,10 +248,10 @@ fn test_collect_extint_nouns() {
 fn test_collect_char_nouns() {
     let a = vec![
         Word::Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec!['a', 'b']).unwrap(),
+            a: Array::from_shape_vec(IxDyn(&[2]), vec![Char::new('a'), Char::new('b')]).unwrap(),
         }),
         Word::Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec!['c', 'd']).unwrap(),
+            a: Array::from_shape_vec(IxDyn(&[2]), vec![Char::new('c'), Char::new('d')]).unwrap(),
         }),
     ];
     let result = collect_nouns(a).unwrap();
@@ -259,7 +259,16 @@ fn test_collect_char_nouns() {
     assert_eq!(
         result,
         Word::Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec!['a', 'b', 'c', 'd']).unwrap(),
+            a: Array::from_shape_vec(
+                IxDyn(&[2, 2]),
+                vec![
+                    Char::new('a'),
+                    Char::new('b'),
+                    Char::new('c'),
+                    Char::new('d')
+                ]
+            )
+            .unwrap(),
         }),
     );
 }

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -1,6 +1,6 @@
 use jr::verbs::reshape;
 use jr::JArray::*;
-use jr::{collect_nouns, Char, ModifierImpl, VerbImpl, Word};
+use jr::{char_array, collect_nouns, Char, ModifierImpl, VerbImpl, Word};
 use ndarray::prelude::*;
 
 #[test]
@@ -246,14 +246,7 @@ fn test_collect_extint_nouns() {
 
 #[test]
 fn test_collect_char_nouns() {
-    let a = vec![
-        Word::Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![Char::new('a'), Char::new('b')]).unwrap(),
-        }),
-        Word::Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![Char::new('c'), Char::new('d')]).unwrap(),
-        }),
-    ];
+    let a = vec![char_array("ab").unwrap(), char_array("cd").unwrap()];
     let result = collect_nouns(a).unwrap();
     println!("result: {:?}", result);
     assert_eq!(


### PR DESCRIPTION
If we make a wrapper type for Char, we can use the same `collect`. This has no runtime (memory) penalty, but will likely limit our ability to find intrinsics later. Maybe we should transition to `u16` instead?