### PR TITLE
chore: anonymise array field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "log"
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -203,9 +203,9 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -223,18 +223,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -72,9 +72,9 @@ pub fn c_hatco(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word, J
         (Word::Verb(_, u), Word::Noun(ja)) => {
             let n = match ja {
                 // TODO is there a better way to do this without needing to cast?
-                JArray::BoolArray { a } => Ok(a.map(|i| *i as i64)),
-                JArray::IntArray { a } => Ok(a.map(|i| *i as i64)),
-                JArray::ExtIntArray { a } => Ok(a.map(|i| *i as i64)),
+                JArray::BoolArray(a) => Ok(a.map(|i| *i as i64)),
+                JArray::IntArray(a) => Ok(a.map(|i| *i as i64)),
+                JArray::ExtIntArray(a) => Ok(a.map(|i| *i as i64)),
                 _ => Err(JError::DomainError),
             }
             .unwrap();

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -84,9 +84,7 @@ fn scan_litnumarray(sentence: &str) -> Result<(usize, Word), JError> {
         match a {
             Ok(a) => Ok((
                 l,
-                Noun(FloatArray {
-                    a: ArrayD::from_shape_vec(IxDyn(&[a.len()]), a)?,
-                }),
+                Noun(FloatArray(ArrayD::from_shape_vec(IxDyn(&[a.len()]), a)?)),
             )),
             Err(_) => Err(JError::custom("parse float error")),
         }
@@ -99,9 +97,7 @@ fn scan_litnumarray(sentence: &str) -> Result<(usize, Word), JError> {
         match a {
             Ok(a) => Ok((
                 l,
-                Noun(IntArray {
-                    a: ArrayD::from_shape_vec(IxDyn(&[a.len()]), a)?,
-                }),
+                Noun(IntArray(ArrayD::from_shape_vec(IxDyn(&[a.len()]), a)?)),
             )),
             Err(_) => Err(JError::custom("parse int error")),
         }

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -88,51 +88,25 @@ impl VerbImpl {
 fn promotion(x: &JArray, y: &JArray) -> Result<(JArray, JArray), JError> {
     // https://code.jsoftware.com/wiki/Vocabulary/NumericPrecisions#Automatic_Promotion_of_Argument_Precision
     match (x, y) {
-        (BoolArray { a: x }, BoolArray { a: y }) => Ok((
-            IntArray {
-                a: x.map(|i| *i as i64),
-            },
-            IntArray {
-                a: y.map(|i| *i as i64),
-            },
+        (BoolArray(x), BoolArray(y)) => Ok((
+            IntArray(x.map(|i| *i as i64)),
+            IntArray(y.map(|i| *i as i64)),
         )),
-        (BoolArray { a: x }, IntArray { a: y }) => Ok((
-            IntArray {
-                a: x.map(|i| *i as i64),
-            },
-            IntArray { a: y.clone() },
-        )),
-        (IntArray { a: x }, BoolArray { a: y }) => Ok((
-            IntArray { a: x.clone() },
-            IntArray {
-                a: y.map(|i| *i as i64),
-            },
-        )),
-        (BoolArray { a: x }, FloatArray { a: y }) => Ok((
-            FloatArray {
-                a: x.map(|i| *i as f64),
-            },
-            FloatArray { a: y.clone() },
-        )),
-        (FloatArray { a: x }, BoolArray { a: y }) => Ok((
-            FloatArray { a: x.clone() },
-            FloatArray {
-                a: y.map(|i| *i as f64),
-            },
-        )),
+        (BoolArray(x), IntArray(y)) => Ok((IntArray(x.map(|i| *i as i64)), IntArray(y.clone()))),
+        (IntArray(x), BoolArray(y)) => Ok((IntArray(x.clone()), IntArray(y.map(|i| *i as i64)))),
+        (BoolArray(x), FloatArray(y)) => {
+            Ok((FloatArray(x.map(|i| *i as f64)), FloatArray(y.clone())))
+        }
+        (FloatArray(x), BoolArray(y)) => {
+            Ok((FloatArray(x.clone()), FloatArray(y.map(|i| *i as f64))))
+        }
 
-        (IntArray { a: x }, FloatArray { a: y }) => Ok((
-            FloatArray {
-                a: x.map(|i| *i as f64),
-            },
-            FloatArray { a: y.clone() },
-        )),
-        (FloatArray { a: x }, IntArray { a: y }) => Ok((
-            FloatArray { a: x.clone() },
-            FloatArray {
-                a: y.map(|i| *i as f64),
-            },
-        )),
+        (IntArray(x), FloatArray(y)) => {
+            Ok((FloatArray(x.map(|i| *i as f64)), FloatArray(y.clone())))
+        }
+        (FloatArray(x), IntArray(y)) => {
+            Ok((FloatArray(x.clone()), FloatArray(y.map(|i| *i as f64))))
+        }
         _ => Ok((x.clone(), y.clone())),
     }
 }
@@ -146,13 +120,9 @@ pub fn v_plus(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => Err(JError::custom("monadic + not implemented yet")),
         Some(x) => match (x, y) {
             (Word::Noun(x), Word::Noun(y)) => match promotion(x, y) {
-                Ok((IntArray { a: x }, IntArray { a: y })) => Ok(Word::Noun(IntArray { a: x + y })),
-                Ok((ExtIntArray { a: x }, ExtIntArray { a: y })) => {
-                    Ok(Word::Noun(ExtIntArray { a: x + y }))
-                }
-                Ok((FloatArray { a: x }, FloatArray { a: y })) => {
-                    Ok(Word::Noun(FloatArray { a: x + y }))
-                }
+                Ok((IntArray(x), IntArray(y))) => Ok(Word::Noun(IntArray(x + y))),
+                Ok((ExtIntArray(x), ExtIntArray(y))) => Ok(Word::Noun(ExtIntArray(x + y))),
+                Ok((FloatArray(x), FloatArray(y))) => Ok(Word::Noun(FloatArray(x + y))),
                 Err(e) => Err(e),
                 _ => Err(JError::DomainError),
             },
@@ -166,13 +136,9 @@ pub fn v_minus(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => Err(JError::custom("monadic - not implemented yet")),
         Some(x) => match (x, y) {
             (Word::Noun(x), Word::Noun(y)) => match promotion(x, y) {
-                Ok((IntArray { a: x }, IntArray { a: y })) => Ok(Word::Noun(IntArray { a: x - y })),
-                Ok((ExtIntArray { a: x }, ExtIntArray { a: y })) => {
-                    Ok(Word::Noun(ExtIntArray { a: x - y }))
-                }
-                Ok((FloatArray { a: x }, FloatArray { a: y })) => {
-                    Ok(Word::Noun(FloatArray { a: x - y }))
-                }
+                Ok((IntArray(x), IntArray(y))) => Ok(Word::Noun(IntArray(x - y))),
+                Ok((ExtIntArray(x), ExtIntArray(y))) => Ok(Word::Noun(ExtIntArray(x - y))),
+                Ok((FloatArray(x), FloatArray(y))) => Ok(Word::Noun(FloatArray(x - y))),
                 Err(e) => Err(e),
                 _ => Err(JError::DomainError),
             },
@@ -186,13 +152,9 @@ pub fn v_star(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => Err(JError::custom("monadic * not implemented yet")),
         Some(x) => match (x, y) {
             (Word::Noun(x), Word::Noun(y)) => match promotion(x, y) {
-                Ok((IntArray { a: x }, IntArray { a: y })) => Ok(Word::Noun(IntArray { a: x * y })),
-                Ok((ExtIntArray { a: x }, ExtIntArray { a: y })) => {
-                    Ok(Word::Noun(ExtIntArray { a: x * y }))
-                }
-                Ok((FloatArray { a: x }, FloatArray { a: y })) => {
-                    Ok(Word::Noun(FloatArray { a: x * y }))
-                }
+                Ok((IntArray(x), IntArray(y))) => Ok(Word::Noun(IntArray(x * y))),
+                Ok((ExtIntArray(x), ExtIntArray(y))) => Ok(Word::Noun(ExtIntArray(x * y))),
+                Ok((FloatArray(x), FloatArray(y))) => Ok(Word::Noun(FloatArray(x * y))),
                 Err(e) => Err(e),
                 _ => Err(JError::DomainError),
             },
@@ -206,13 +168,9 @@ pub fn v_percent(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => Err(JError::custom("monadic % not implemented yet")),
         Some(x) => match (x, y) {
             (Word::Noun(x), Word::Noun(y)) => match promotion(x, y) {
-                Ok((IntArray { a: x }, IntArray { a: y })) => Ok(Word::Noun(IntArray { a: x / y })),
-                Ok((ExtIntArray { a: x }, ExtIntArray { a: y })) => {
-                    Ok(Word::Noun(ExtIntArray { a: x / y }))
-                }
-                Ok((FloatArray { a: x }, FloatArray { a: y })) => {
-                    Ok(Word::Noun(FloatArray { a: x / y }))
-                }
+                Ok((IntArray(x), IntArray(y))) => Ok(Word::Noun(IntArray(x / y))),
+                Ok((ExtIntArray(x), ExtIntArray(y))) => Ok(Word::Noun(ExtIntArray(x / y))),
+                Ok((FloatArray(x), FloatArray(y))) => Ok(Word::Noun(FloatArray(x / y))),
                 Err(e) => Err(e),
                 _ => Err(JError::DomainError),
             },
@@ -246,7 +204,7 @@ pub fn v_dollar(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         Some(x) => {
             // Reshape
             match x {
-                Word::Noun(IntArray { a: x }) => {
+                Word::Noun(IntArray(x)) => {
                     if x.product() < 0 {
                         Err(JError::DomainError)
                     } else {
@@ -291,18 +249,10 @@ pub fn v_starco(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => {
             // Square
             match y {
-                Word::Noun(BoolArray { a }) => Ok(Word::Noun(BoolArray {
-                    a: a.clone() * a.clone(),
-                })),
-                Word::Noun(IntArray { a }) => Ok(Word::Noun(IntArray {
-                    a: a.clone() * a.clone(),
-                })),
-                Word::Noun(ExtIntArray { a }) => Ok(Word::Noun(ExtIntArray {
-                    a: a.clone() * a.clone(),
-                })),
-                Word::Noun(FloatArray { a }) => Ok(Word::Noun(FloatArray {
-                    a: a.clone() * a.clone(),
-                })),
+                Word::Noun(BoolArray(a)) => Ok(Word::Noun(BoolArray(a.clone() * a.clone()))),
+                Word::Noun(IntArray(a)) => Ok(Word::Noun(IntArray(a.clone() * a.clone()))),
+                Word::Noun(ExtIntArray(a)) => Ok(Word::Noun(ExtIntArray(a.clone() * a.clone()))),
+                Word::Noun(FloatArray(a)) => Ok(Word::Noun(FloatArray(a.clone() * a.clone()))),
                 _ => Err(JError::DomainError),
             }
         }
@@ -314,18 +264,16 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
     match x {
         None => match y {
             // monadic i.
-            Word::Noun(IntArray { a }) => {
+            Word::Noun(IntArray(a)) => {
                 let p = a.product();
                 if p < 0 {
                     todo!("monadic i. negative args");
                 } else {
                     let ints = Array::from_vec((0..p).collect());
-                    Ok(Noun(IntArray {
-                        a: reshape(a, &ints.into_dyn()).unwrap(),
-                    }))
+                    Ok(Noun(IntArray(reshape(a, &ints.into_dyn()).unwrap())))
                 }
             }
-            Word::Noun(ExtIntArray { a: _ }) => {
+            Word::Noun(ExtIntArray(_)) => {
                 todo!("monadic i. ExtIntArray")
             }
             _ => Err(JError::DomainError),
@@ -335,7 +283,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
             // dyadic i.
             (Word::Noun(x), Word::Noun(y)) => match (x, y) {
                 // TODO remove code duplication: map_array!, apply_array_homo!, homo_array!, impl_array! ???
-                (BoolArray { a: x }, BoolArray { a: y }) => {
+                (BoolArray(x), BoolArray(y)) => {
                     let positions: Vec<i64> = y
                         .outer_iter()
                         .map(|i| {
@@ -344,11 +292,11 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    }))
+                    Ok(Word::Noun(IntArray(
+                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
+                    )))
                 }
-                (CharArray { a: x }, CharArray { a: y }) => {
+                (CharArray(x), CharArray(y)) => {
                     let positions: Vec<i64> = y
                         .outer_iter()
                         .map(|i| {
@@ -357,11 +305,11 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    }))
+                    Ok(Word::Noun(IntArray(
+                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
+                    )))
                 }
-                (IntArray { a: x }, IntArray { a: y }) => {
+                (IntArray(x), IntArray(y)) => {
                     let positions: Vec<i64> = y
                         .outer_iter()
                         .map(|i| {
@@ -373,11 +321,11 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    }))
+                    Ok(Word::Noun(IntArray(
+                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
+                    )))
                 }
-                (ExtIntArray { a: x }, ExtIntArray { a: y }) => {
+                (ExtIntArray(x), ExtIntArray(y)) => {
                     let positions: Vec<i64> = y
                         .outer_iter()
                         .map(|i| {
@@ -386,11 +334,11 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    }))
+                    Ok(Word::Noun(IntArray(
+                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
+                    )))
                 }
-                (FloatArray { a: x }, FloatArray { a: y }) => {
+                (FloatArray(x), FloatArray(y)) => {
                     let positions: Vec<i64> = y
                         .outer_iter()
                         .map(|i| {
@@ -399,17 +347,15 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    }))
+                    Ok(Word::Noun(IntArray(
+                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
+                    )))
                 }
                 _ => {
                     // mismatched array types
                     let xl = x.len_of(Axis(0)) as i64;
                     let yl = y.len_of(Axis(0));
-                    Ok(Word::Noun(IntArray {
-                        a: Array::from_elem(IxDyn(&[yl]), xl),
-                    }))
+                    Ok(Word::Noun(IntArray(Array::from_elem(IxDyn(&[yl]), xl))))
                 }
             },
             _ => Err(JError::DomainError),

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -25,9 +25,9 @@ fn test_scan_num() {
     let words = jr::scan("1 2 _3\n").unwrap();
     assert_eq!(
         words,
-        [Word::Noun(IntArray {
-            a: ArrayD::from_shape_vec(IxDyn(&[3]), vec![1, 2, -3]).unwrap()
-        })]
+        [Word::Noun(IntArray(
+            ArrayD::from_shape_vec(IxDyn(&[3]), vec![1, 2, -3]).unwrap()
+        ))]
     );
 }
 

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -10,25 +10,21 @@ fn test_basic_addition() {
     let words = jr::scan("2 + 2").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[1]), 4)
-        })
+        Noun(IntArray(Array::from_elem(IxDyn(&[1]), 4)))
     );
 
     let words = jr::scan("1 2 3 + 4 5 6").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[3]), vec![5, 7, 9]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[3]), vec![5, 7, 9]).unwrap()
+        ))
     );
 
     let words = jr::scan("1 + 3.14").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(FloatArray {
-            a: Array::from_elem(IxDyn(&[1]), 1.0 + 3.14)
-        })
+        Noun(FloatArray(Array::from_elem(IxDyn(&[1]), 1.0 + 3.14)))
     );
 }
 
@@ -37,36 +33,34 @@ fn test_basic_times() {
     let words = jr::scan("2 * 2").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[1]), 4)
-        })
+        Noun(IntArray(Array::from_elem(IxDyn(&[1]), 4)))
     );
 
     let words = jr::scan("1 2 3 * 4 5 6").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[3]), vec![4, 10, 18]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[3]), vec![4, 10, 18]).unwrap()
+        ))
     );
 }
 
 #[test]
 fn test_parse_basics() {
     let words = vec![
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[1]), vec![2]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[1]), vec![2]).unwrap(),
+        )),
         Verb(String::from("+"), VerbImpl::Plus),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[3]), vec![1, 2, 3]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[3]), vec![1, 2, 3]).unwrap(),
+        )),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[3]), vec![3, 4, 5]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[3]), vec![3, 4, 5]).unwrap()
+        ))
     );
 }
 
@@ -75,9 +69,7 @@ fn test_insert_adverb() {
     let words = jr::scan("+/1 2 3").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[]), 6)
-        })
+        Noun(IntArray(Array::from_elem(IxDyn(&[]), 6)))
     );
 }
 
@@ -86,33 +78,31 @@ fn test_reshape() {
     let words = jr::scan("2 2 $ 1 2 3 4").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec![1, 2, 3, 4]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2, 2]), vec![1, 2, 3, 4]).unwrap()
+        ))
     );
 
     let words = jr::scan("4 $ 1").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[4]), 1)
-        })
+        Noun(IntArray(Array::from_elem(IxDyn(&[4]), 1)))
     );
 
     let words = jr::scan("1 2 3 $ 1 2").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[1, 2, 3]), vec![1, 2, 1, 2, 1, 2]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[1, 2, 3]), vec![1, 2, 1, 2, 1, 2]).unwrap()
+        ))
     );
 
     let words = jr::scan("3 $ 2 2 $ 0 1 2 3").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[3, 2]), vec![0, 1, 2, 3, 0, 1]).unwrap()
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[3, 2]), vec![0, 1, 2, 3, 0, 1]).unwrap()
+        ))
     );
 }
 
@@ -129,18 +119,16 @@ fn test_power_conjunction_bool_arg() {
     let words = vec![
         Verb(String::from("*:"), VerbImpl::StarCo),
         Conjunction(String::from("^:"), ModifierImpl::HatCo),
-        Noun(BoolArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
-        }),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[]), 4),
-        }),
+        Noun(BoolArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
+        )),
+        Noun(IntArray(Array::from_elem(IxDyn(&[]), 4))),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![4, 16]).unwrap(),
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![4, 16]).unwrap(),
+        ))
     );
 }
 
@@ -150,97 +138,91 @@ fn test_power_conjunction_noun_arg() {
     let words = vec![
         Verb(String::from("*:"), VerbImpl::StarCo),
         Conjunction(String::from("^:"), ModifierImpl::HatCo),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[]), 2),
-        }),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[]), 4),
-        }),
+        Noun(IntArray(Array::from_elem(IxDyn(&[]), 2))),
+        Noun(IntArray(Array::from_elem(IxDyn(&[]), 4))),
     ];
     // TODO Should the result be an atom 256 here? rather than an array of shape 1?
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[1]), 256)
-        })
+        Noun(IntArray(Array::from_elem(IxDyn(&[1]), 256)))
     );
 
     let words = vec![
         Verb(String::from("*:"), VerbImpl::StarCo),
         Conjunction(String::from("^:"), ModifierImpl::HatCo),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
-        }),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
+        )),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
+        )),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec![16, 81, 256, 6561]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2, 2]), vec![16, 81, 256, 6561]).unwrap(),
+        )),
     );
 }
 
 #[test]
 fn test_collect_int_nouns() {
     let a = vec![
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
-        }),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
+        )),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
+        )),
     ];
     //let result = collect_int_nouns(a).unwrap();
     let result = collect_nouns(a).unwrap();
     println!("result: {:?}", result);
     assert_eq!(
         result,
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec![0, 1, 2, 3]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2, 2]), vec![0, 1, 2, 3]).unwrap(),
+        )),
     );
 }
 
 #[test]
 fn test_collect_extint_nouns() {
     let a = vec![
-        Noun(ExtIntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
-        }),
-        Noun(ExtIntArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
-        }),
+        Noun(ExtIntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![0, 1]).unwrap(),
+        )),
+        Noun(ExtIntArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec![2, 3]).unwrap(),
+        )),
     ];
     let result = collect_nouns(a).unwrap();
     println!("result: {:?}", result);
     assert_eq!(
         result,
-        Noun(ExtIntArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec![0, 1, 2, 3]).unwrap(),
-        }),
+        Noun(ExtIntArray(
+            Array::from_shape_vec(IxDyn(&[2, 2]), vec![0, 1, 2, 3]).unwrap(),
+        )),
     );
 }
 
 #[test]
 fn test_collect_char_nouns() {
     let a = vec![
-        Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec!['a', 'b']).unwrap(),
-        }),
-        Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2]), vec!['c', 'd']).unwrap(),
-        }),
+        Noun(CharArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec!['a', 'b']).unwrap(),
+        )),
+        Noun(CharArray(
+            Array::from_shape_vec(IxDyn(&[2]), vec!['c', 'd']).unwrap(),
+        )),
     ];
     let result = collect_nouns(a).unwrap();
     println!("result: {:?}", result);
     assert_eq!(
         result,
-        Noun(CharArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 2]), vec!['a', 'b', 'c', 'd']).unwrap(),
-        }),
+        Noun(CharArray(
+            Array::from_shape_vec(IxDyn(&[2, 2]), vec!['a', 'b', 'c', 'd']).unwrap(),
+        )),
     );
 }
 
@@ -264,9 +246,9 @@ fn test_fork() {
                 h: Box::new(Verb(String::from("#"), VerbImpl::Number)),
             },
         ),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[5]), vec![1, 2, 3, 4, 5]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[5]), vec![1, 2, 3, 4, 5]).unwrap(),
+        )),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
@@ -286,9 +268,9 @@ fn test_fork_noun() {
                 h: Box::new(Verb(String::from("#"), VerbImpl::Number)),
             },
         ),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[5]), vec![1, 2, 3, 4, 5]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[5]), vec![1, 2, 3, 4, 5]).unwrap(),
+        )),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
@@ -307,9 +289,9 @@ fn test_hook() {
                 r: Box::new(Verb(String::from("#"), VerbImpl::Number)),
             },
         ),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[6]), vec![3, 1, 4, 1, 5, 9]).unwrap(),
-        }),
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[6]), vec![3, 1, 4, 1, 5, 9]).unwrap(),
+        )),
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
@@ -321,15 +303,15 @@ fn test_hook() {
 fn test_idot() {
     assert_eq!(
         jr::eval(jr::scan("i. 4").unwrap(), &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[4]), vec![0, 1, 2, 3]).unwrap(),
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[4]), vec![0, 1, 2, 3]).unwrap(),
+        ))
     );
     assert_eq!(
         jr::eval(jr::scan("i. 2 3").unwrap(), &mut HashMap::new()).unwrap(),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[2, 3]), vec![0, 1, 2, 3, 4, 5]).unwrap(),
-        })
+        Noun(IntArray(
+            Array::from_shape_vec(IxDyn(&[2, 3]), vec![0, 1, 2, 3, 4, 5]).unwrap(),
+        ))
     );
 }
 
@@ -383,15 +365,11 @@ fn test_assignment() {
     let mut names = HashMap::new();
     assert_eq!(
         jr::eval(jr::scan("a =: 42").unwrap(), &mut names).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[1]), 42)
-        })
+        int_array([42].as_slice()).unwrap()
     );
     assert_eq!(
         jr::eval(jr::scan("a").unwrap(), &mut names).unwrap(),
-        Noun(IntArray {
-            a: Array::from_elem(IxDyn(&[1]), 42)
-        })
+        int_array([42].as_slice()).unwrap()
     );
 }
 
@@ -400,17 +378,13 @@ fn test_resolve_names() {
     let mut names = HashMap::new();
     names.insert(
         String::from("a"),
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[6]), vec![3, 1, 4, 1, 5, 9]).unwrap(),
-        }),
+        int_array([3, 1, 4, 1, 5, 9].as_slice()).unwrap(),
     );
 
     let words = (
         Name(String::from("a")),
         IsLocal,
-        Noun(IntArray {
-            a: Array::from_shape_vec(IxDyn(&[6]), vec![3, 1, 4, 1, 5, 9]).unwrap(),
-        }),
+        int_array([3, 1, 4, 1, 5, 9].as_slice()).unwrap(),
         Nothing,
     );
     assert_eq!(resolve_names(words.clone(), names.clone()), words);
@@ -426,9 +400,7 @@ fn test_resolve_names() {
         (
             Name(String::from("b")),
             IsLocal,
-            Noun(IntArray {
-                a: Array::from_shape_vec(IxDyn(&[6]), vec![3, 1, 4, 1, 5, 9]).unwrap(),
-            }),
+            int_array(vec![3i64, 1, 4, 1, 5, 9]).unwrap(),
             Nothing,
         )
     );


### PR DESCRIPTION
`IntArray { a }` -> `IntArray(a)` seems quite a bit neater, and an annoying diff.