### PR TITLE
chore: some macro unification

### DIFF
--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -178,7 +178,6 @@ impl JArray {
     }
 }
 
-use JArray::*;
 use Word::*;
 
 pub trait HasEmpty {
@@ -291,7 +290,7 @@ impl Word {
 }
 
 pub fn int_array(v: impl Arrayable<i64>) -> Result<Word, JError> {
-    Ok(Word::Noun(v.into_array()?.into_jarray()))
+    Word::noun(v)
 }
 
 pub fn char_array(x: impl AsRef<str>) -> Result<Word, JError> {
@@ -304,30 +303,13 @@ pub fn char_array(x: impl AsRef<str>) -> Result<Word, JError> {
 
 impl Word {
     pub fn to_cells(&self) -> Result<Vec<Word>, JError> {
-        match self {
-            Noun(ja) => match ja {
-                IntArray(a) => Ok(a
-                    .outer_iter()
-                    .map(|a| Noun(IntArray(a.into_owned())))
-                    .collect::<Vec<Word>>()),
-                ExtIntArray(a) => Ok(a
-                    .outer_iter()
-                    .map(|a| Noun(ExtIntArray(a.into_owned())))
-                    .collect::<Vec<Word>>()),
-                FloatArray(a) => Ok(a
-                    .outer_iter()
-                    .map(|a| Noun(FloatArray(a.into_owned())))
-                    .collect::<Vec<Word>>()),
-                BoolArray(a) => Ok(a
-                    .outer_iter()
-                    .map(|a| Noun(BoolArray(a.into_owned())))
-                    .collect::<Vec<Word>>()),
-                CharArray(a) => Ok(a
-                    .outer_iter()
-                    .map(|a| Noun(CharArray(a.into_owned())))
-                    .collect::<Vec<Word>>()),
-            },
-            _ => panic!("only nouns can be split into cells"),
-        }
+        let ja = match self {
+            Noun(ja) => ja,
+            _ => return Err(JError::DomainError),
+        };
+        Ok(impl_array!(ja, |a: &ArrayBase<_, _>| a
+            .outer_iter()
+            .map(|a| Noun(a.into_owned().into_jarray()))
+            .collect()))
     }
 }

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -226,12 +226,6 @@ impl_into_jarray!(ArrayD<i64>, JArray::IntArray);
 impl_into_jarray!(ArrayD<i128>, JArray::ExtIntArray);
 impl_into_jarray!(ArrayD<f64>, JArray::FloatArray);
 
-// impl IntoJArray for ArrayD<i64> {
-//     fn into_jarray(self) -> JArray {
-//         JArray::IntArray(self)
-//     }
-// }
-
 // like IntoIterator<Item = T> + ExactSizeIterator
 pub trait Arrayable<T> {
     fn len(&self) -> usize;
@@ -289,16 +283,9 @@ impl Word {
     }
 }
 
-pub fn int_array(v: impl Arrayable<i64>) -> Result<Word, JError> {
-    Word::noun(v)
-}
-
 pub fn char_array(x: impl AsRef<str>) -> Result<Word, JError> {
-    let x = x.as_ref();
-    Ok(Word::Noun(JArray::CharArray(ArrayD::from_shape_vec(
-        IxDyn(&[x.chars().count()]),
-        x.chars().collect(),
-    )?)))
+    let v: Vec<char> = x.as_ref().chars().collect();
+    Word::noun(v)
 }
 
 impl Word {

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -117,19 +117,6 @@ pub enum JArray {
 }
 
 #[macro_export]
-macro_rules! map_array {
-    ($arr:ident, $func:expr) => {
-        match $arr {
-            JArray::BoolArray(a) => JArray::BoolArray($func(a)?),
-            JArray::CharArray(a) => JArray::CharArray($func(a)?),
-            JArray::IntArray(a) => JArray::IntArray($func(a)?),
-            JArray::ExtIntArray(a) => JArray::ExtIntArray($func(a)?),
-            JArray::FloatArray(a) => JArray::FloatArray($func(a)?),
-        }
-    };
-}
-
-#[macro_export]
 macro_rules! apply_array_homo {
     ($arr:ident, $func:expr) => {
         match $arr.iter().next().ok_or(JError::DomainError)? {
@@ -152,6 +139,7 @@ macro_rules! apply_array_homo {
     };
 }
 
+#[macro_export]
 macro_rules! impl_array {
     ($arr:ident, $func:expr) => {
         match $arr {
@@ -215,6 +203,12 @@ impl_empty!(f64, 0.);
 
 pub trait IntoJArray {
     fn into_jarray(self) -> JArray;
+    fn into_noun(self) -> Word
+    where
+        Self: Sized,
+    {
+        Word::Noun(self.into_jarray())
+    }
 }
 
 macro_rules! impl_into_jarray {

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -1,4 +1,3 @@
-use crate::int_array;
 use crate::JArray;
 use crate::JError;
 use crate::Word;
@@ -184,7 +183,9 @@ pub fn v_number(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => {
             // Tally
             match y {
-                Word::Noun(ja) => int_array([ja.len()].as_slice()),
+                Word::Noun(ja) => {
+                    Word::noun([i64::try_from(ja.len()).map_err(|_| JError::LimitError)?])
+                }
                 _ => Err(JError::DomainError),
             }
         }
@@ -197,7 +198,7 @@ pub fn v_dollar(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
         None => {
             // Shape-of
             match y {
-                Word::Noun(ja) => int_array(ja.shape()),
+                Word::Noun(ja) => Word::noun(ja.shape()),
                 _ => Err(JError::DomainError),
             }
         }

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -6,7 +6,8 @@ use ndarray::prelude::*;
 use std::fmt::Debug;
 use std::ops::Deref;
 
-use crate::map_array;
+use crate::arrays::IntoJArray as _;
+use crate::impl_array;
 
 use JArray::*;
 use Word::*;
@@ -210,7 +211,9 @@ pub fn v_dollar(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                         Err(JError::DomainError)
                     } else {
                         match y {
-                            Word::Noun(ja) => Ok(Word::Noun(map_array!(ja, |y| reshape(x, y)))),
+                            Word::Noun(ja) => {
+                                impl_array!(ja, |y| reshape(x, y).map(|x| x.into_noun()))
+                            }
                             _ => Err(JError::DomainError),
                         }
                     }

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -296,9 +296,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray(
-                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    )))
+                    Word::noun(positions)
                 }
                 (CharArray(x), CharArray(y)) => {
                     let positions: Vec<i64> = y
@@ -309,9 +307,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray(
-                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    )))
+                    Word::noun(positions)
                 }
                 (IntArray(x), IntArray(y)) => {
                     let positions: Vec<i64> = y
@@ -325,9 +321,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray(
-                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    )))
+                    Word::noun(positions)
                 }
                 (ExtIntArray(x), ExtIntArray(y)) => {
                     let positions: Vec<i64> = y
@@ -338,9 +332,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray(
-                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    )))
+                    Word::noun(positions)
                 }
                 (FloatArray(x), FloatArray(y)) => {
                     let positions: Vec<i64> = y
@@ -351,9 +343,7 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
                                 .unwrap_or(x.len_of(Axis(0))) as i64
                         })
                         .collect();
-                    Ok(Word::Noun(IntArray(
-                        Array::from_shape_vec(IxDyn(&[positions.len()]), positions).unwrap(),
-                    )))
+                    Word::noun(positions)
                 }
                 _ => {
                     // mismatched array types

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -286,65 +286,12 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
             // TODO fix for n-dimensional arguments. currently broken
             // dyadic i.
             (Word::Noun(x), Word::Noun(y)) => match (x, y) {
-                // TODO remove code duplication: map_array!, apply_array_homo!, homo_array!, impl_array! ???
-                (BoolArray(x), BoolArray(y)) => {
-                    let positions: Vec<i64> = y
-                        .outer_iter()
-                        .map(|i| {
-                            x.outer_iter()
-                                .position(|j| j == i)
-                                .unwrap_or(x.len_of(Axis(0))) as i64
-                        })
-                        .collect();
-                    Word::noun(positions)
-                }
-                (CharArray(x), CharArray(y)) => {
-                    let positions: Vec<i64> = y
-                        .outer_iter()
-                        .map(|i| {
-                            x.outer_iter()
-                                .position(|j| j == i)
-                                .unwrap_or(x.len_of(Axis(0))) as i64
-                        })
-                        .collect();
-                    Word::noun(positions)
-                }
-                (IntArray(x), IntArray(y)) => {
-                    let positions: Vec<i64> = y
-                        .outer_iter()
-                        .map(|i| {
-                            x.outer_iter()
-                                .position(|j| {
-                                    debug!("j:{}, i:{}", j, i);
-                                    j == i
-                                })
-                                .unwrap_or(x.len_of(Axis(0))) as i64
-                        })
-                        .collect();
-                    Word::noun(positions)
-                }
-                (ExtIntArray(x), ExtIntArray(y)) => {
-                    let positions: Vec<i64> = y
-                        .outer_iter()
-                        .map(|i| {
-                            x.outer_iter()
-                                .position(|j| j == i)
-                                .unwrap_or(x.len_of(Axis(0))) as i64
-                        })
-                        .collect();
-                    Word::noun(positions)
-                }
-                (FloatArray(x), FloatArray(y)) => {
-                    let positions: Vec<i64> = y
-                        .outer_iter()
-                        .map(|i| {
-                            x.outer_iter()
-                                .position(|j| j == i)
-                                .unwrap_or(x.len_of(Axis(0))) as i64
-                        })
-                        .collect();
-                    Word::noun(positions)
-                }
+                // TODO remove code duplication: impl_array_pair!? impl_array_binary!?
+                (BoolArray(x), BoolArray(y)) => v_idot_positions(x, y),
+                (CharArray(x), CharArray(y)) => v_idot_positions(x, y),
+                (IntArray(x), IntArray(y)) => v_idot_positions(x, y),
+                (ExtIntArray(x), ExtIntArray(y)) => v_idot_positions(x, y),
+                (FloatArray(x), FloatArray(y)) => v_idot_positions(x, y),
                 _ => {
                     // mismatched array types
                     let xl = x.len_of(Axis(0)) as i64;
@@ -355,4 +302,16 @@ pub fn v_idot(x: Option<&Word>, y: &Word) -> Result<Word, JError> {
             _ => Err(JError::DomainError),
         },
     }
+}
+
+fn v_idot_positions<T: PartialEq>(x: &ArrayD<T>, y: &ArrayD<T>) -> Result<Word, JError> {
+    Word::noun(
+        y.outer_iter()
+            .map(|i| {
+                x.outer_iter()
+                    .position(|j| j == i)
+                    .unwrap_or(x.len_of(Axis(0))) as i64
+            })
+            .collect::<Vec<i64>>(),
+    )
 }

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -1,7 +1,7 @@
 use jr::verbs::reshape;
 use jr::JArray::*;
 use jr::Word::*;
-use jr::{collect_nouns, int_array, resolve_names, JError, ModifierImpl, VerbImpl, Word};
+use jr::{collect_nouns, resolve_names, JError, ModifierImpl, VerbImpl, Word};
 use ndarray::prelude::*;
 use std::collections::HashMap;
 
@@ -263,7 +263,7 @@ fn test_fork_noun() {
         Verb(
             String::from("+/%#"),
             VerbImpl::Fork {
-                f: Box::new(int_array(vec![15]).unwrap()),
+                f: Box::new(Word::noun(vec![15i64]).unwrap()),
                 g: Box::new(Verb(String::from("%"), VerbImpl::Percent)),
                 h: Box::new(Verb(String::from("#"), VerbImpl::Number)),
             },
@@ -274,7 +274,7 @@ fn test_fork_noun() {
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        int_array(vec![3]).unwrap()
+        Word::noun(vec![3i64]).unwrap()
     );
 }
 
@@ -295,7 +295,7 @@ fn test_hook() {
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        int_array(vec![6]).unwrap()
+        Word::noun(vec![6i64]).unwrap()
     );
 }
 
@@ -365,11 +365,11 @@ fn test_assignment() {
     let mut names = HashMap::new();
     assert_eq!(
         jr::eval(jr::scan("a =: 42").unwrap(), &mut names).unwrap(),
-        int_array([42].as_slice()).unwrap()
+        Word::noun([42i64]).unwrap()
     );
     assert_eq!(
         jr::eval(jr::scan("a").unwrap(), &mut names).unwrap(),
-        int_array([42].as_slice()).unwrap()
+        Word::noun([42i64]).unwrap()
     );
 }
 
@@ -378,13 +378,13 @@ fn test_resolve_names() {
     let mut names = HashMap::new();
     names.insert(
         String::from("a"),
-        int_array([3, 1, 4, 1, 5, 9].as_slice()).unwrap(),
+        Word::noun([3i64, 1, 4, 1, 5, 9]).unwrap(),
     );
 
     let words = (
         Name(String::from("a")),
         IsLocal,
-        int_array([3, 1, 4, 1, 5, 9].as_slice()).unwrap(),
+        Word::noun([3i64, 1, 4, 1, 5, 9]).unwrap(),
         Nothing,
     );
     assert_eq!(resolve_names(words.clone(), names.clone()), words);
@@ -400,7 +400,7 @@ fn test_resolve_names() {
         (
             Name(String::from("b")),
             IsLocal,
-            int_array(vec![3i64, 1, 4, 1, 5, 9]).unwrap(),
+            Word::noun([3i64, 1, 4, 1, 5, 9]).unwrap(),
             Nothing,
         )
     );

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -252,7 +252,7 @@ fn test_fork() {
     ];
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
-        int_array(vec![3]).unwrap()
+        Word::noun([3i64]).unwrap()
     );
 }
 


### PR DESCRIPTION
`map_array` is just `impl_array` with `.intoto_jarray()`, which now exists.

`int_array` is a special case of `Word::noun(anything which could be made into an array)`.

`vdot` is a regular generic function!