### PR TITLE
chore: homogenising promotion

### DIFF
--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -116,6 +116,25 @@ pub enum JArray {
     //EmptyArray, // How do we do this properly?
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum ArrayPair {
+    BoolPair(ArrayD<u8>, ArrayD<u8>),
+    CharPair(ArrayD<char>, ArrayD<char>),
+    IntPair(ArrayD<i64>, ArrayD<i64>),
+    ExtIntPair(ArrayD<i128>, ArrayD<i128>),
+    FloatPair(ArrayD<f64>, ArrayD<f64>),
+}
+
+impl ArrayPair {
+    fn plus(&self) -> JArray {
+        use ArrayPair::*;
+        match self {
+            BoolPair(x, y) => (x + y).into_jarray(),
+            _ => todo!(),
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! apply_array_homo {
     ($arr:ident, $func:expr) => {
@@ -271,6 +290,20 @@ impl<T: Clone, const N: usize> Arrayable<T> for [T; N] {
 
     fn into_vec(self) -> Result<Vec<T>, JError> {
         Ok(self.to_vec())
+    }
+}
+
+impl<T> Arrayable<T> for ArrayD<T> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn into_vec(self) -> Result<Vec<T>, JError> {
+        Ok(self.into_raw_vec())
+    }
+
+    fn into_array(self) -> Result<ArrayD<T>, JError> {
+        Ok(self)
     }
 }
 

--- a/src/arrays.rs
+++ b/src/arrays.rs
@@ -119,20 +119,36 @@ pub enum JArray {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArrayPair {
     BoolPair(ArrayD<u8>, ArrayD<u8>),
-    CharPair(ArrayD<char>, ArrayD<char>),
     IntPair(ArrayD<i64>, ArrayD<i64>),
     ExtIntPair(ArrayD<i128>, ArrayD<i128>),
     FloatPair(ArrayD<f64>, ArrayD<f64>),
+    // CharArray(..) // char, again, lacks maths operators, making this annoying
+}
+
+macro_rules! impl_pair {
+    ($arr:ident, $func:expr) => {
+        match $arr {
+            ArrayPair::BoolPair(x, y) => $func(x, y),
+            ArrayPair::IntPair(x, y) => $func(x, y),
+            ArrayPair::ExtIntPair(x, y) => $func(x, y),
+            ArrayPair::FloatPair(x, y) => $func(x, y),
+        }
+    };
+}
+
+macro_rules! impl_pair_op {
+    ($name:ident, $op:path) => {
+        pub fn $name(&self) -> JArray {
+            impl_pair!(self, |x: &ArrayD<_>, y: &ArrayD<_>| $op(x, y).into_jarray())
+        }
+    };
 }
 
 impl ArrayPair {
-    fn plus(&self) -> JArray {
-        use ArrayPair::*;
-        match self {
-            BoolPair(x, y) => (x + y).into_jarray(),
-            _ => todo!(),
-        }
-    }
+    impl_pair_op!(plus, ::std::ops::Add::add);
+    impl_pair_op!(minus, ::std::ops::Sub::sub);
+    impl_pair_op!(star, ::std::ops::Mul::mul);
+    impl_pair_op!(slash, ::std::ops::Div::div);
 }
 
 #[macro_export]

--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -85,11 +85,11 @@ impl VerbImpl {
 fn prohomo(x: &JArray, y: &JArray) -> Result<ArrayPair, JError> {
     use ArrayPair::*;
     Ok(match (x, y) {
-        (BoolArray(x), BoolArray(y)) => IntPair(x.caast()?, y.caast()?),
-        (BoolArray(x), IntArray(y)) => IntPair(x.caast()?, y.clone()),
-        (IntArray(x), BoolArray(y)) => IntPair(x.clone(), y.caast()?),
-        (BoolArray(x), FloatArray(y)) => FloatPair(x.caast()?, y.clone()),
-        (FloatArray(x), BoolArray(y)) => FloatPair(x.clone(), y.caast()?),
+        (BoolArray(x), BoolArray(y)) => IntPair(x.cast()?, y.cast()?),
+        (BoolArray(x), IntArray(y)) => IntPair(x.cast()?, y.clone()),
+        (IntArray(x), BoolArray(y)) => IntPair(x.clone(), y.cast()?),
+        (BoolArray(x), FloatArray(y)) => FloatPair(x.cast()?, y.clone()),
+        (FloatArray(x), BoolArray(y)) => FloatPair(x.clone(), y.cast()?),
 
         (IntArray(x), FloatArray(y)) => FloatPair(x.map(|i| *i as f64), y.clone()),
         (FloatArray(x), IntArray(y)) => FloatPair(x.clone(), y.map(|i| *i as f64)),
@@ -103,18 +103,11 @@ fn prohomo(x: &JArray, y: &JArray) -> Result<ArrayPair, JError> {
 }
 
 trait ArrayUtil<A> {
-    fn cast<T: From<A>>(&self) -> Result<JArray, JError>
-    where
-        ArrayD<T>: IntoJArray,
-    {
-        Ok(self.caast()?.into_jarray())
-    }
-
-    fn caast<T: From<A>>(&self) -> Result<ArrayD<T>, JError>;
+    fn cast<T: From<A>>(&self) -> Result<ArrayD<T>, JError>;
 }
 
 impl<A: Copy> ArrayUtil<A> for ArrayD<A> {
-    fn caast<T: From<A>>(&self) -> Result<ArrayD<T>, JError> {
+    fn cast<T: From<A>>(&self) -> Result<ArrayD<T>, JError> {
         Ok(self.map(|&e| T::try_from(e).expect("todo: LimitError?")))
     }
 }


### PR DESCRIPTION
Follows #36.

A binary version of `impl_array`?

`promotion` now returns a `Pair` of identical arrays, and then maths operators can be implemented on `Pair`, instead of everywhere?

`v_starco` and `v_idot` also want to do this, but need to handle `chars`, and maybe don't want promotions? Maybe they do and you couldn't face it? Maybe we need a non-promoting version of homogenisation, which returns a non-maths pair, or we need to go back to a type of `char` which implements some maths operators?

Or we could stop using ops::Add::add and just "define" addition on char using.. some other trait monstrosity.

This PR doesn't actually reduce lines of code much, but it feels "correct" to me, the macros have moved "into" the enums (even though it's a new enum), and away from the "application code" (in `v_plus`)?