### PR TITLE
feat: implement monadic behead

### DIFF
--- a/src/verbs.rs
+++ b/src/verbs.rs
@@ -701,8 +701,15 @@ pub fn v_amend_m_u(_x: &Word, _y: &Word) -> Result<Word> {
 }
 
 /// }. (monad)
-pub fn v_behead(_y: &Word) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_behead(y: &Word) -> Result<Word> {
+    match y {
+        Word::Noun(arr) => impl_array!(arr, |arr: &ArrayD<_>| Ok(Array::from_iter(
+            arr.iter().cloned().skip(1)
+        )
+        .into_dyn()
+        .into_noun())),
+        _ => return Err(JError::DomainError.into()),
+    }
 }
 /// }. (dyad)
 pub fn v_drop(_x: &Word, _y: &Word) -> Result<Word> {

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -1,9 +1,12 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use ndarray::prelude::*;
+
 use jr::verbs::reshape;
 use jr::JArray::*;
 use jr::Word::*;
 use jr::{collect_nouns, resolve_names, ModifierImpl, VerbImpl, Word};
-use ndarray::prelude::*;
-use std::collections::HashMap;
 
 #[test]
 fn test_basic_addition() {
@@ -408,6 +411,15 @@ fn test_parens() {
         jr::eval(jr::scan("2 * 2 + 4").unwrap(), &mut names).unwrap(),
         Word::noun([12i64]).unwrap()
     );
+}
+
+#[test]
+fn test_behead() -> Result<()> {
+    assert_eq!(
+        jr::eval(jr::scan("}. 5 6 7")?, &mut HashMap::new())?,
+        Word::noun([6i64, 7])?
+    );
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Assumes flat arrays, which is likely completely wrong.

As an example of #48.