### PR TITLE
feat: agreement, but wrong

### DIFF
--- a/src/arrays/cow.rs
+++ b/src/arrays/cow.rs
@@ -66,6 +66,21 @@ impl<'v> From<JArrayCow<'v>> for JArray {
     }
 }
 
+impl<'v> From<&'v JArray> for JArrayCow<'v> {
+    fn from(value: &'v JArray) -> Self {
+        match value {
+            JArray::BoolArray(v) => JArrayCow::BoolArray(v.into()),
+            JArray::CharArray(v) => JArrayCow::CharArray(v.into()),
+            JArray::IntArray(v) => JArrayCow::IntArray(v.into()),
+            JArray::ExtIntArray(v) => JArrayCow::ExtIntArray(v.into()),
+            JArray::RationalArray(v) => JArrayCow::RationalArray(v.into()),
+            JArray::FloatArray(v) => JArrayCow::FloatArray(v.into()),
+            JArray::ComplexArray(v) => JArrayCow::ComplexArray(v.into()),
+            JArray::BoxArray(v) => JArrayCow::BoxArray(v.into()),
+        }
+    }
+}
+
 macro_rules! impl_from_nd {
     ($t:ty, $j:path) => {
         impl<'v> From<ArrayD<$t>> for JArrayCow<'v> {

--- a/src/arrays/cow.rs
+++ b/src/arrays/cow.rs
@@ -35,11 +35,11 @@ macro_rules! impl_array {
 
 impl<'v> JArrayCow<'v> {
     pub fn len(&self) -> usize {
-        impl_array!(self, |x: &ArrayBase<_, _>| x.len())
+        impl_array!(self, ArrayBase::len)
     }
 
-    pub fn shape(&'v self) -> &[usize] {
-        impl_array!(self, |x: &'v ArrayBase<_, _>| x.shape())
+    pub fn shape(&self) -> &[usize] {
+        impl_array!(self, ArrayBase::shape)
     }
 
     // TODO: Iterator

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use itertools::Itertools;
 use log::debug;
 use ndarray::prelude::*;
@@ -22,6 +22,23 @@ pub fn common_dims(x: &[usize], y: &[usize]) -> usize {
         .unwrap_or_else(|| x.len().min(y.len()))
 }
 
+fn frame_of(shape: &[usize], rank: Rank) -> Result<&[usize]> {
+    Ok(match rank.usize() {
+        None => shape,
+        Some(rank) => {
+            ensure!(rank <= shape.len(), "rank {rank:?} higher than {shape:?}");
+            &shape[..shape.len() - rank]
+        }
+    })
+}
+
+fn cells_of(a: &JArray, arg_rank: Rank, surplus_rank: usize) -> Result<JArrayCow> {
+    Ok(match arg_rank.usize() {
+        None => JArrayCow::from(a),
+        Some(arg_rank) => a.choppo(surplus_rank + arg_rank)?,
+    })
+}
+
 pub fn generate_cells<'x, 'y>(
     x: &'x JArray,
     y: &'y JArray,
@@ -35,8 +52,8 @@ pub fn generate_cells<'x, 'y>(
 
     let min_rank = x_rank.min(y_rank);
 
-    let x_frame = &x_shape[..x_rank - x_arg_rank.usize()];
-    let y_frame = &y_shape[..y_rank - y_arg_rank.usize()];
+    let x_frame = frame_of(x_shape, x_arg_rank)?;
+    let y_frame = frame_of(y_shape, y_arg_rank)?;
 
     let common_dims = common_dims(x_frame, y_frame);
     let common_frame = &x_shape[..common_dims];
@@ -52,8 +69,8 @@ pub fn generate_cells<'x, 'y>(
     let x_surplus_rank = x_rank - min_rank;
     let y_surplus_rank = y_rank - min_rank;
 
-    let x_cells = x.choppo(x_surplus_rank + x_arg_rank.usize())?;
-    let y_cells = y.choppo(y_surplus_rank + y_arg_rank.usize())?;
+    let x_cells = cells_of(x, x_arg_rank, x_surplus_rank)?;
+    let y_cells = cells_of(y, y_arg_rank, y_surplus_rank)?;
 
     debug!("x_cells: {x_cells:?}");
     debug!("y_cells: {y_cells:?}");
@@ -76,7 +93,7 @@ pub fn apply_cells<'v>(
         .collect()
 }
 
-pub fn flatten(shape: &[usize], vecs: Vec<Word>) -> Result<JArray> {
+pub fn flatten(shape: &[usize], vecs: &[Word]) -> Result<JArray> {
     let arr = vecs
         .iter()
         .map(|w| match w {

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -61,6 +61,21 @@ pub fn generate_cells<'x, 'y>(
     Ok((x_cells, y_cells))
 }
 
+// TODO: garbage lifetime sharing here, don't pass the CoW objects by reference
+pub fn apply_cells<'v>(
+    (x_cells, y_cells): (&'v JArrayCow<'v>, &'v JArrayCow<'v>),
+    f: fn(&JArray, &JArray) -> Result<Word>,
+) -> Result<Vec<Word>> {
+    x_cells
+        .outer_iter()
+        .into_iter()
+        .cycle()
+        .zip(y_cells.outer_iter().into_iter().cycle())
+        .take(x_cells.shape()[0].max(y_cells.shape()[0]))
+        .map(|(x, y)| f(&x.into(), &y.into()))
+        .collect()
+}
+
 pub fn flatten(shape: &[usize], vecs: Vec<Word>) -> Result<JArray> {
     let arr = vecs
         .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod plot;
 use std::collections::HashMap;
 
 pub use arrays::*;
+pub use cells::flatten;
 pub use empty::HasEmpty;
 pub use error::JError;
 pub use eval::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
 
         "^" => primitive("^", v_exponential, v_power, (0, 0, 0)),
         "^." => primitive("^.", v_natural_log, v_logarithm, (0, 0, 0)),
-        "$" => primitive("$", v_shape_of, v_shape, (inf, 1, inf)),
+        "$" => primitive("$", v_shape_of, v_shape, (inf, /* todo: 1 */ inf, inf)),
         "~:" => primitive("~:", v_nub_sieve, v_not_equal, (inf, 0, 0)),
         "|" => primitive("|", v_magnitude, v_residue, (0, 0, 0)),
         "|." => primitive("|.", v_reverse, v_rotate_shift, (inf, inf, inf)),

--- a/src/verbs/ranks.rs
+++ b/src/verbs/ranks.rs
@@ -36,7 +36,14 @@ impl Rank {
         (Self::infinite(), Self::infinite())
     }
 
-    pub fn usize(&self) -> usize {
-        usize::from(self.0)
+    pub const fn is_infinite(&self) -> bool {
+        self.0 == u8::MAX
+    }
+
+    pub fn usize(&self) -> Option<usize> {
+        if self.is_infinite() {
+            return None;
+        }
+        Some(usize::from(self.0))
     }
 }

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -48,7 +48,6 @@ fn array_iter_2_3_2() -> Result<()> {
 }
 
 #[test]
-#[ignore]
 fn test_agreement() {
     let words = jr::scan("10 20 + i.2 3").unwrap();
     assert_eq!(
@@ -58,7 +57,6 @@ fn test_agreement() {
 }
 
 #[test]
-#[ignore]
 fn test_agreement_2() -> Result<()> {
     let err = jr::eval(jr::scan("1 2 3 + i. 2 3")?, &mut HashMap::new()).unwrap_err();
     let root = dbg!(err.root_cause())

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -50,7 +50,7 @@ fn test_basic_times() {
 fn test_parse_basics() {
     let words = vec![
         Noun(IntArray(
-            Array::from_shape_vec(IxDyn(&[1]), vec![2]).unwrap(),
+            Array::from_shape_vec(IxDyn(&[]), vec![2]).unwrap(),
         )),
         Word::static_verb("+"),
         Noun(IntArray(


### PR DESCRIPTION
Wire up the "agreement" code from the #53, which isn't correct, but passes almost all of the existing tests.

`$` is broken (very, very broken), but it can be fixed by claiming it's `(inf, inf)`, bypassing the new code.

This gives us apparently-working happy path addition, multiplication, and the like, and (hopefully) slightly useful errors for the remaining insanely broken cases. From here, I propose we try and work out what is wrong with one of the functions in `cells.rs`, which are called, in order, from `exec_dyad`, which is very simple apart from error message generation.

