### PR TITLE
rip: move choppo over to rank_iter

### DIFF
--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -1,7 +1,6 @@
 use std::{fmt, iter};
 
-use anyhow::{bail, Context, Result};
-use itertools::Itertools;
+use anyhow::{Context, Result};
 use ndarray::prelude::*;
 use ndarray::IntoDimension;
 use num::complex::Complex64;
@@ -127,20 +126,6 @@ impl JArray {
                 .map(|x| x.into_shape(surplus).unwrap().into_owned().into_jarray())
                 .collect())
         }
-    }
-
-    pub fn choppo(&self, nega_rank: usize) -> Result<JArrayCow> {
-        let shape = self.shape();
-
-        if nega_rank > shape.len() {
-            bail!("cannot ({}) given a shape of {:?}", nega_rank, shape);
-        }
-
-        let (common, surplus) = shape.split_at(shape.len() - nega_rank);
-        let p = common.iter().product::<usize>();
-        let new_shape = iter::once(p).chain(surplus.iter().copied()).collect_vec();
-
-        self.to_shape(new_shape)
     }
 
     pub fn into_nums(self) -> Result<Vec<Num>> {

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -118,15 +118,6 @@ fn test_agreement_plus_rank1() {
 }
 
 #[test]
-fn test_jarray_choppo() -> Result<()> {
-    let a = array![[1i64, 2, 3], [5, 6, 7]].into_dyn().into_jarray();
-    assert_eq!(a.choppo(0)?.shape()[0], 6);
-    assert_eq!(a.choppo(1)?.shape()[0], 2);
-    assert_eq!(a.choppo(2)?.shape()[0], 1);
-    Ok(())
-}
-
-#[test]
 fn test_agreement_reshape_3() -> Result<()> {
     let r1 = jr::eval(jr::scan("6 $ i.2 3")?, &mut HashMap::new()).unwrap();
     // 6 3 $ 0 1 2 3 4 5 0 1 2 3 4 5 0 1 2 3 4 5


### PR DESCRIPTION
`choppo` is equivalent enough to `rank_iter` according to the tests, so switch to the new impl