### PR TITLE
feat: simple >: ("increment") implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812a2ec2043c4d6bc6482f5be2ab8244613cac2493d128d36c0759e52a626ab3"
+checksum = "203974af07ea769452490ee8de3e5947971efc3a090dca8a779dd432d3fa46a7"
 dependencies = [
  "bitflags",
  "errno",

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -7,7 +7,7 @@ mod word;
 pub use arrayable::Arrayable;
 pub use cow::{CowArrayD, JArrayCow};
 pub use owned::{IntoJArray, JArray};
-pub use plural::{ArrayPair, JArrays};
+pub use plural::JArrays;
 pub use word::Word;
 
 // All terminology should match J terminology:

--- a/src/arrays/plural.rs
+++ b/src/arrays/plural.rs
@@ -3,17 +3,8 @@ use ndarray::prelude::*;
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
-use super::{CowArrayD, IntoJArray, Word};
-use crate::{HasEmpty, JArray, JError};
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum ArrayPair<'l, 'r> {
-    BoolPair(CowArrayD<'l, u8>, CowArrayD<'r, u8>),
-    IntPair(CowArrayD<'l, i64>, CowArrayD<'r, i64>),
-    ExtIntPair(CowArrayD<'l, BigInt>, CowArrayD<'r, BigInt>),
-    FloatPair(CowArrayD<'l, f64>, CowArrayD<'r, f64>),
-    // CharArray(..) // char, again, lacks maths operators, making this annoying
-}
+use super::Word;
+use crate::{JArray, JError};
 
 #[derive(Debug)]
 pub enum JArrays<'v> {
@@ -54,43 +45,4 @@ impl<'a> JArrays<'a> {
             BoxArray(_) => BoxArrays(homo!(BoxArray, arrs.iter())),
         })
     }
-}
-
-macro_rules! impl_pair {
-    ($arr:ident, $func:expr) => {
-        match $arr {
-            ArrayPair::BoolPair(x, y) => $func(x, y),
-            ArrayPair::IntPair(x, y) => $func(x, y),
-            ArrayPair::ExtIntPair(x, y) => $func(x, y),
-            ArrayPair::FloatPair(x, y) => $func(x, y),
-        }
-    };
-}
-
-macro_rules! impl_pair_op {
-    ($name:ident, $op:path) => {
-        pub fn $name(&self) -> JArray {
-            impl_pair!(self, |x, y| ($op(x, y) as ArrayD<_>).into_jarray())
-        }
-    };
-}
-
-impl ArrayPair<'_, '_> {
-    impl_pair_op!(plus, ::std::ops::Add::add);
-    impl_pair_op!(minus, ::std::ops::Sub::sub);
-    impl_pair_op!(star, ::std::ops::Mul::mul);
-    impl_pair_op!(slash, ::std::ops::Div::div);
-    impl_pair_op!(lessthan, elementwise_lt);
-}
-
-fn elementwise_lt<T: Clone + HasEmpty + PartialOrd>(
-    x: &CowArrayD<T>,
-    y: &CowArrayD<T>,
-) -> ArrayD<i64> {
-    // TODO - not quite right when x and y shapes are different, fix generically:
-    // https://code.jsoftware.com/wiki/Vocabulary/Agreement
-    let empty_shape = x.shape();
-    let mut result: ArrayD<i64> = ArrayD::from_elem(empty_shape, HasEmpty::empty());
-    azip!((a in &mut result, x in x, y in y) *a = if x < y { 1 } else { 0 });
-    result
 }

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -148,7 +148,11 @@ pub fn flatten(
             if arr.shape() == target_inner_shape {
                 // TODO: don't clone
 
-                big_daddy.extend(arr.clone().into_nums()?);
+                big_daddy.extend(
+                    arr.clone()
+                        .into_nums()
+                        .ok_or_else(|| anyhow!("lazyness around nums / elems"))?,
+                );
                 continue;
             }
 
@@ -157,7 +161,11 @@ pub fn flatten(
                     let current = arr.shape()[0];
                     let target = target_inner_shape[0];
                     assert!(current < target, "{current} < {target}: single-dimensional fill can't see longer or equal shapes");
-                    big_daddy.extend(arr.clone().into_nums()?);
+                    big_daddy.extend(
+                        arr.clone()
+                            .into_nums()
+                            .ok_or_else(|| anyhow!("lazyness around nums / elems"))?,
+                    );
                     for _ in current..target {
                         big_daddy.push(Num::Bool(0));
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ pub mod arrays;
 pub mod cells;
 mod empty;
 mod error;
-use ndarray::{ArrayD, IxDyn};
 pub mod eval;
 pub mod modifiers;
 pub mod scan;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 pub mod arrays;
 pub mod cells;
 mod empty;

--- a/src/scan/number.rs
+++ b/src/scan/number.rs
@@ -3,7 +3,7 @@ use std::ops;
 
 use num::complex::Complex64;
 use num::{BigInt, BigRational, Integer};
-use num_traits::{CheckedMul, One, ToPrimitive, Zero};
+use num_traits::{One, ToPrimitive, Zero};
 
 #[derive(Debug, Clone)]
 pub enum Num {
@@ -24,6 +24,20 @@ impl Num {
             Num::Rational(i) => i.to_f64()?,
             Num::Float(i) => *i,
             Num::Complex(_) => return None,
+        })
+    }
+
+    /// true if the value looks like a 1, regardless of type; false if it looks like a 0
+    pub fn value_bool(self) -> Option<bool> {
+        Some(match self {
+            Num::Bool(i) => i == 1,
+            Num::Int(i) if i == 1 => true,
+            Num::Int(i) if i == 0 => false,
+            Num::Int(_) => return None,
+            Num::ExtInt(i) if i.is_one() => true,
+            Num::ExtInt(i) if i.is_zero() => false,
+            Num::ExtInt(_) => return None,
+            other => return other.demote().value_bool(),
         })
     }
 
@@ -49,6 +63,10 @@ impl Num {
 
     pub fn one() -> Self {
         Num::Bool(1)
+    }
+
+    pub fn i() -> Self {
+        Num::Complex(Complex64::new(0., 1.))
     }
 }
 

--- a/src/verbs/maff.rs
+++ b/src/verbs/maff.rs
@@ -1,0 +1,17 @@
+use anyhow::{Context, Result};
+
+use crate::{JArray, JError, Num, Word};
+
+pub fn rank0(x: &JArray, y: &JArray, f: impl FnOnce(Num, Num) -> Result<Num>) -> Result<Word> {
+    let x = x
+        .single_math_num()
+        .ok_or(JError::DomainError)
+        .context("expecting a single number for 'x'")?;
+
+    let y = y
+        .single_math_num()
+        .ok_or(JError::DomainError)
+        .context("expecting a single number for 'y'")?;
+
+    Ok(Word::Noun(f(x, y)?.into()))
+}

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -370,8 +370,12 @@ pub fn v_larger_of_max(_x: &JArray, _y: &JArray) -> Result<Word> {
 }
 
 /// >: (monad)
-pub fn v_increment(_y: &JArray) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_increment(y: &JArray) -> Result<Word> {
+    let num = y
+        .single_math_num()
+        .ok_or(JError::DomainError)
+        .context("increment expects a single number")?;
+    Ok(Word::Noun((num + Num::one()).into()))
 }
 /// >: (dyad)
 pub fn v_larger_or_equal(_x: &JArray, _y: &JArray) -> Result<Word> {
@@ -484,7 +488,7 @@ pub fn v_reciprocal(y: &JArray) -> Result<Word> {
     let num = y
         .clone()
         .into_nums()
-        .map_err(|_| JError::DomainError)?
+        .ok_or_else(|| JError::DomainError)?
         .into_iter()
         .next()
         .expect("checked length");
@@ -673,7 +677,11 @@ pub fn v_copy(x: &JArray, y: &JArray) -> Result<Word> {
             let repetitions = i.iter().copied().next().expect("checked");
             ensure!(repetitions > 0, "unimplemented: {repetitions} repetitions");
             let mut output = Vec::new();
-            for item in y.clone().into_nums()? {
+            for item in y
+                .clone()
+                .into_nums()
+                .ok_or_else(|| anyhow!("lazyness around nums / elems"))?
+            {
                 for _ in 0..repetitions {
                     output.push(item.clone());
                 }

--- a/tests/agreement.rs
+++ b/tests/agreement.rs
@@ -89,25 +89,7 @@ fn test_agreement_4() -> Result<()> {
 
 #[test]
 fn test_agreement_plus_rank1() {
-    // 1 2 3 +"1 i.2 3
-    let x = array![1i64, 2, 3].into_dyn().into_noun();
-    let y =
-        Word::noun(Array::from_shape_vec(IxDyn(&[2, 3]), (0i64..6).collect()).unwrap()).unwrap();
-
-    use jr::verbs::*;
-
-    // +"1
-    let f = Word::Verb(
-        "+\"1".to_string(),
-        VerbImpl::Primitive(PrimitiveImpl::new(
-            "+",
-            v_conjugate,
-            v_plus,
-            (Rank::zero(), Rank::one(), Rank::one()),
-        )),
-    );
-
-    let words = vec![x, f, y];
+    let words = jr::scan("1 2 3 +\"1 i.2 3").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
         Array::from_shape_vec(IxDyn(&[2, 3]), vec![1i64, 3, 5, 4, 6, 8])

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -9,7 +9,7 @@ use num::{BigInt, BigRational};
 use jr::verbs::reshape;
 use jr::JArray::*;
 use jr::Word::*;
-use jr::{arr0d, collect_nouns, eval, resolve_names, scan, IntoJArray, JArray, Rank, Word};
+use jr::{arr0d, collect_nouns, eval, resolve_names, scan, JArray, Rank, Word};
 
 // AA TODO scan_eval and idot don't live here, was too lazy to get git to cherry pick nicely
 //use jr::test_impls::{idot, scan_eval};
@@ -452,7 +452,7 @@ fn test_increment() {
     assert_eq!(s(&format!(">: {}", i64::MAX - 1)), Word::from(i64::MAX));
     assert_eq!(
         s(&format!(">: {}", i64::MAX)),
-        Word::from(BigInt::from(i64::MAX) + 1)
+        Word::from((i64::MAX as f64) + 1.)
     );
     assert_eq!(
         s(">: 5r11"),
@@ -572,24 +572,7 @@ fn test_rank_conjunction_0_1() {
 #[test]
 fn test_agreement_plus_rank_0_1() {
     // Add each atom of x to each vector of y (same as test_rank_conjunction_0_1() but without the rank conjunction)
-    //    1 2 (+"0 1) 1 2 3
-    let x = array![1i64, 2].into_dyn().into_noun();
-    let y = Word::noun([1i64, 2, 3]).unwrap();
-
-    use jr::verbs::*;
-
-    // +"0 1
-    let f = Word::Verb(
-        "+\"0 1".to_string(),
-        VerbImpl::Primitive(PrimitiveImpl::new(
-            "+",
-            v_conjugate,
-            v_plus,
-            (Rank::zero(), Rank::zero(), Rank::one()),
-        )),
-    );
-
-    let words = vec![x, f, y];
+    let words = jr::scan("1 2 (+\"0 1) 1 2 3").unwrap();
     assert_eq!(
         jr::eval(words, &mut HashMap::new()).unwrap(),
         Noun(IntArray(


### PR DESCRIPTION
Add a slightly better math abstraction, where we can do things with a type (`Num`) which implements some operators, instead of macros, enabling at least slightly complex verbs to be implemented in one line.

I would bet there's bugs in the promotion rules for minus/divide/multiply, but they're currently useful enough?