### PR TITLE
feat: Elem

### DIFF
--- a/src/arrays/elem.rs
+++ b/src/arrays/elem.rs
@@ -37,3 +37,14 @@ impl From<Word> for Elem {
         Elem::Boxed(value)
     }
 }
+
+impl PartialEq for Elem {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Elem::Num(l), Elem::Num(r)) => l == r,
+            (Elem::Boxed(l), Elem::Boxed(r)) => l == r,
+            (Elem::Char(l), Elem::Char(r)) => l == r,
+            _ => false,
+        }
+    }
+}

--- a/src/arrays/elem.rs
+++ b/src/arrays/elem.rs
@@ -1,0 +1,39 @@
+use crate::{Num, Word};
+use num::complex::Complex64;
+use num::{BigInt, BigRational};
+
+#[derive(Clone, Debug)]
+pub enum Elem {
+    Num(Num),
+    Char(char),
+    Boxed(Word),
+}
+
+macro_rules! from_num {
+    ($t:ty) => {
+        impl From<$t> for Elem {
+            fn from(value: $t) -> Self {
+                Self::Num(value.into())
+            }
+        }
+    };
+}
+
+from_num!(u8);
+from_num!(i64);
+from_num!(BigInt);
+from_num!(BigRational);
+from_num!(f64);
+from_num!(Complex64);
+
+impl From<char> for Elem {
+    fn from(value: char) -> Self {
+        Elem::Char(value)
+    }
+}
+
+impl From<Word> for Elem {
+    fn from(value: Word) -> Self {
+        Elem::Boxed(value)
+    }
+}

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -1,11 +1,13 @@
 mod arrayable;
 mod cow;
+mod elem;
 mod owned;
 mod plural;
 mod word;
 
 pub use arrayable::Arrayable;
 pub use cow::{CowArrayD, JArrayCow};
+pub use elem::Elem;
 pub use owned::{IntoJArray, JArray};
 pub use plural::JArrays;
 pub use word::Word;

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -174,6 +174,19 @@ impl JArray {
         })
     }
 
+    pub fn single_elem(&self) -> Option<Elem> {
+        if self.len() != 1 {
+            return None;
+        }
+        Some(
+            self.clone()
+                .into_elems()
+                .into_iter()
+                .next()
+                .expect("checked"),
+        )
+    }
+
     pub fn single_math_num(&self) -> Option<Num> {
         if self.len() != 1 {
             return None;
@@ -375,6 +388,16 @@ impl From<Num> for JArray {
             Num::Rational(a) => JArray::from(a),
             Num::Float(a) => JArray::from(a),
             Num::Complex(a) => JArray::from(a),
+        }
+    }
+}
+
+impl From<Elem> for JArray {
+    fn from(value: Elem) -> Self {
+        match value {
+            Elem::Char(a) => JArray::from(a),
+            Elem::Boxed(a) => JArray::from(a),
+            Elem::Num(a) => JArray::from(a),
         }
     }
 }

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -9,6 +9,7 @@ use num::{BigInt, BigRational};
 use num_traits::ToPrimitive;
 
 use super::{CowArrayD, JArrayCow};
+use crate::arrays::elem::Elem;
 use crate::{Num, Word};
 
 #[derive(Clone, PartialEq)]
@@ -143,6 +144,22 @@ impl JArray {
         }
     }
 
+    pub fn into_elems(self) -> Vec<Elem> {
+        use JArray::*;
+        // don't understand why the macro won't work here
+        // Ok(impl_array!(self, |a: ArrayD<_>| a.into_iter().map(|v| v.into()).collect()))
+        match self {
+            BoolArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            CharArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            IntArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            ExtIntArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            RationalArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            FloatArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            ComplexArray(a) => a.into_iter().map(|v| v.into()).collect(),
+            BoxArray(a) => a.into_iter().map(|v| v.into()).collect(),
+        }
+    }
+
     pub fn into_nums(self) -> Option<Vec<Num>> {
         use JArray::*;
         Some(match self {
@@ -152,7 +169,6 @@ impl JArray {
             RationalArray(a) => a.into_iter().map(|v| v.into()).collect(),
             FloatArray(a) => a.into_iter().map(|v| v.into()).collect(),
             ComplexArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            // Num isn't the real return type here, but it does exist, and have working promotions
             CharArray(_) => return None,
             BoxArray(_) => return None,
         })

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -3,8 +3,9 @@ use std::cmp::max;
 use anyhow::{anyhow, bail, Context, Result};
 use itertools::Itertools;
 use log::debug;
+use num_traits::Zero;
 
-use crate::{promote_to_array, DyadRank, JArray, JError, Num, Rank, Word};
+use crate::{promote_to_array, DyadRank, Elem, JArray, JError, Num, Rank, Word};
 
 pub fn common_dims(x: &[usize], y: &[usize]) -> usize {
     x.iter()
@@ -142,17 +143,13 @@ pub fn flatten(
         .collect_vec();
 
     // flatten
-    let mut big_daddy: Vec<Num> = Vec::new();
+    let mut big_daddy: Vec<Elem> = Vec::new();
     for macrocell in macrocell_results {
         for arr in macrocell {
             if arr.shape() == target_inner_shape {
                 // TODO: don't clone
 
-                big_daddy.extend(
-                    arr.clone()
-                        .into_nums()
-                        .ok_or_else(|| anyhow!("lazyness around nums / elems"))?,
-                );
+                big_daddy.extend(arr.clone().into_elems());
                 continue;
             }
 
@@ -161,13 +158,9 @@ pub fn flatten(
                     let current = arr.shape()[0];
                     let target = target_inner_shape[0];
                     assert!(current < target, "{current} < {target}: single-dimensional fill can't see longer or equal shapes");
-                    big_daddy.extend(
-                        arr.clone()
-                            .into_nums()
-                            .ok_or_else(|| anyhow!("lazyness around nums / elems"))?,
-                    );
+                    big_daddy.extend(arr.clone().into_elems());
                     for _ in current..target {
-                        big_daddy.push(Num::Bool(0));
+                        big_daddy.push(Elem::Num(Num::zero()));
                     }
                 }
                 _ => {

--- a/src/scan/number.rs
+++ b/src/scan/number.rs
@@ -16,6 +16,14 @@ pub enum Num {
 }
 
 impl Num {
+    pub fn bool(val: bool) -> Num {
+        if val {
+            Num::Bool(1)
+        } else {
+            Num::Bool(0)
+        }
+    }
+
     pub fn approx_f64(&self) -> Option<f64> {
         Some(match self {
             Num::Bool(i) => *i as f64,

--- a/src/verbs/maff.rs
+++ b/src/verbs/maff.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 
-use crate::{JArray, JError, Num, Word};
+use crate::{Elem, JArray, JError, Num, Word};
 
+/// rank: (0, 0), input: any Num, output: Result<Num>
 pub fn rank0(x: &JArray, y: &JArray, f: impl FnOnce(Num, Num) -> Result<Num>) -> Result<Word> {
     let x = x
         .single_math_num()
@@ -14,4 +15,20 @@ pub fn rank0(x: &JArray, y: &JArray, f: impl FnOnce(Num, Num) -> Result<Num>) ->
         .context("expecting a single number for 'y'")?;
 
     Ok(Word::Noun(f(x, y)?.into()))
+}
+
+/// rank: (0, 0), input: any Element, output: Boolean
+pub fn rank0eb(x: &JArray, y: &JArray, f: impl FnOnce(Elem, Elem) -> bool) -> Result<Word> {
+    let x = x
+        .single_elem()
+        .ok_or(JError::DomainError)
+        .context("expecting a single element for 'x'")?;
+
+    let y = y
+        .single_elem()
+        .ok_or(JError::DomainError)
+        .context("expecting a single element for 'y'")?;
+
+    let v = f(x, y);
+    Ok(Word::Noun(Num::Bool(v as u8).into()))
 }

--- a/src/verbs/maff.rs
+++ b/src/verbs/maff.rs
@@ -30,5 +30,5 @@ pub fn rank0eb(x: &JArray, y: &JArray, f: impl FnOnce(Elem, Elem) -> bool) -> Re
         .context("expecting a single element for 'y'")?;
 
     let v = f(x, y);
-    Ok(Word::Noun(Num::Bool(v as u8).into()))
+    Ok(Word::Noun(Num::bool(v).into()))
 }

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fmt::Debug;
 use std::ops::Deref;
 
-use crate::{arr0d, impl_array, promote_to_array, IntoJArray, JArray, JError, Num, Word};
+use crate::{arr0d, impl_array, promote_to_array, Elem, IntoJArray, JArray, JError, Num, Word};
 
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use log::debug;
@@ -498,7 +498,7 @@ pub fn v_reciprocal(y: &JArray) -> Result<Word> {
         Num::Rational(i) => Num::Rational(BigRational::one() / i),
         Num::Complex(i) => Num::Complex(Complex64::one() / i),
     };
-    Ok(Word::Noun(promote_to_array(vec![result])?))
+    Ok(Word::Noun(promote_to_array(vec![Elem::Num(result)])?))
 }
 /// % (dyad)
 pub fn v_divide(x: &JArray, y: &JArray) -> Result<Word> {
@@ -675,11 +675,7 @@ pub fn v_copy(x: &JArray, y: &JArray) -> Result<Word> {
             let repetitions = i.iter().copied().next().expect("checked");
             ensure!(repetitions > 0, "unimplemented: {repetitions} repetitions");
             let mut output = Vec::new();
-            for item in y
-                .clone()
-                .into_nums()
-                .ok_or_else(|| anyhow!("lazyness around nums / elems"))?
-            {
+            for item in y.clone().into_elems() {
                 for _ in 0..repetitions {
                     output.push(item.clone());
                 }

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -406,7 +406,7 @@ pub fn v_double(_y: &JArray) -> Result<Word> {
 /// +: (dyad)
 pub fn v_not_or(x: &JArray, y: &JArray) -> Result<Word> {
     rank0(x, y, |x, y| match (x.value_bool(), y.value_bool()) {
-        (Some(x), Some(y)) => Ok(Num::Bool(!(x || y) as u8)),
+        (Some(x), Some(y)) => Ok(Num::bool(!(x || y))),
         _ => Err(JError::DomainError).context("boolean operators only except zeros and ones"),
     })
 }
@@ -442,7 +442,7 @@ pub fn v_square(y: &JArray) -> Result<Word> {
 /// *: (dyad)
 pub fn v_not_and(x: &JArray, y: &JArray) -> Result<Word> {
     rank0(x, y, |x, y| match (x.value_bool(), y.value_bool()) {
-        (Some(x), Some(y)) => Ok(Num::Bool(!(x && y) as u8)),
+        (Some(x), Some(y)) => Ok(Num::bool(!(x && y))),
         _ => Err(JError::DomainError).context("boolean operators only except zeros and ones"),
     })
 }

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -18,7 +18,7 @@ use crate::JError::DomainError;
 use JArray::*;
 use Word::*;
 
-use maff::rank0;
+use maff::{rank0, rank0eb};
 pub use ranks::Rank;
 
 #[derive(Copy, Clone)]
@@ -280,8 +280,8 @@ pub fn v_self_classify(_y: &JArray) -> Result<Word> {
     Err(JError::NonceError.into())
 }
 /// = (dyad)
-pub fn v_equal(_x: &JArray, _y: &JArray) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_equal(x: &JArray, y: &JArray) -> Result<Word> {
+    rank0eb(x, y, |x, y| x == y)
 }
 
 pub fn atom_aware_box(y: &JArray) -> JArray {
@@ -549,8 +549,8 @@ pub fn v_nub_sieve(_y: &JArray) -> Result<Word> {
     Err(JError::NonceError.into())
 }
 /// ~: (dyad)
-pub fn v_not_equal(_x: &JArray, _y: &JArray) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_not_equal(x: &JArray, y: &JArray) -> Result<Word> {
+    rank0eb(x, y, |x, y| x != y)
 }
 
 /// | (monad)


### PR DESCRIPTION
Extension to the `Num` enum to cover the `Box` and `Char` cases. Use the new `Elem` type in all the array building code, so we drop the weird limitations there. Now `v_equal` and the like are simple to implement generically, with more `rank0` functions.
