### PR TITLE
chore: apply some clippy warning fixes

### DIFF
--- a/src/arrays/cow.rs
+++ b/src/arrays/cow.rs
@@ -68,7 +68,7 @@ impl<'v> JArrayCow<'v> {
     pub fn outer_iter(&'v self) -> Vec<Self> {
         impl_array!(self, |x: &'v ArrayBase<_, _>| x
             .outer_iter()
-            .map(|x| Self::from(x))
+            .map(Self::from)
             .collect())
     }
 
@@ -86,8 +86,8 @@ impl<'v> JArrayCow<'v> {
             IntArray(a) => a.iter().map(|x| JArrayCow::from(*x)).collect(),
             ExtIntArray(a) => a.iter().map(|x| JArrayCow::from(x.clone())).collect(),
             RationalArray(a) => a.iter().map(|x| JArrayCow::from(x.clone())).collect(),
-            FloatArray(a) => a.iter().map(|x| JArrayCow::from(x.clone())).collect(),
-            ComplexArray(a) => a.iter().map(|x| JArrayCow::from(x.clone())).collect(),
+            FloatArray(a) => a.iter().map(|x| JArrayCow::from(*x)).collect(),
+            ComplexArray(a) => a.iter().map(|x| JArrayCow::from(*x)).collect(),
             BoxArray(a) => a.iter().map(|x| JArrayCow::from(x.clone())).collect(),
         }
     }

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::enum_variant_names)]
+
 mod arrayable;
 mod cow;
 mod elem;

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -74,6 +74,10 @@ macro_rules! map_array {
 }
 
 impl JArray {
+    pub fn is_empty(&self) -> bool {
+        impl_array!(self, |a: &ArrayBase<_, _>| { a.is_empty() })
+    }
+
     pub fn len(&self) -> usize {
         impl_array!(self, |a: &ArrayBase<_, _>| {
             match a.shape() {
@@ -149,7 +153,7 @@ impl JArray {
                 (l.to_vec(), s.to_vec())
             } else {
                 // Negative rank is a real thing in j, it's just the same but from the left instead of the right.
-                let (l, s) = shape.split_at(rank.abs() as usize);
+                let (l, s) = shape.split_at(rank.unsigned_abs() as usize);
                 (l.to_vec(), s.to_vec())
             };
             debug!("leading: {:?}, surplus: {:?}", leading, surplus);

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -172,19 +172,7 @@ impl JArray {
     }
 
     pub fn into_elems(self) -> Vec<Elem> {
-        use JArray::*;
-        // don't understand why the macro won't work here
-        // Ok(impl_array!(self, |a: ArrayD<_>| a.into_iter().map(|v| v.into()).collect()))
-        match self {
-            BoolArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            CharArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            IntArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            ExtIntArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            RationalArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            FloatArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            ComplexArray(a) => a.into_iter().map(|v| v.into()).collect(),
-            BoxArray(a) => a.into_iter().map(|v| v.into()).collect(),
-        }
+        impl_array!(self, |a: ArrayD<_>| a.into_iter().map(Elem::from).collect())
     }
 
     pub fn into_nums(self) -> Option<Vec<Num>> {

--- a/src/bin/jr/main.rs
+++ b/src/bin/jr/main.rs
@@ -53,7 +53,7 @@ fn eval(buffer: &str, names: &mut HashMap<String, Word>) -> Result<bool> {
         return Ok(true);
     }
 
-    match scan_eval(&buffer, names) {
+    match scan_eval(buffer, names) {
         //Ok(output) => println!("{:?}", output),
         Ok(output) => println!("{}", output),
         Err(e) => {

--- a/src/bin/jr/tui.rs
+++ b/src/bin/jr/tui.rs
@@ -128,7 +128,7 @@ impl Hinter for DIYHinter {
         };
 
         let mut helped = HashSet::with_capacity(4);
-        let mut it = v.into_iter().rev().flat_map(|w| match w {
+        let it = v.into_iter().rev().flat_map(|w| match w {
             Word::Verb(token, _) if helped.insert(token.clone()) => {
                 help(&token).into_iter().collect()
             }
@@ -140,7 +140,7 @@ impl Hinter for DIYHinter {
 
         let mut buf = String::with_capacity(64);
 
-        while let Some(word) = it.next() {
+        for word in it {
             if buf.len() > 70 {
                 break;
             }

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -25,7 +25,7 @@ pub enum ModifierImpl {
 }
 
 impl ModifierImpl {
-    pub fn exec<'a>(&'a self, x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
+    pub fn exec(&self, x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
         match self {
             ModifierImpl::NotImplemented => a_not_implemented(x, u, y),
             ModifierImpl::Slash => a_slash(x, u, y),
@@ -105,7 +105,7 @@ pub fn collect_nouns(n: Vec<Word>) -> Result<Word> {
 
 fn collect<T: Clone + HasEmpty>(arr: &[ArrayViewD<T>]) -> Result<ArrayD<T>> {
     // TODO: this special cases the atom/scalar case, as the reshape algorithm mangles it
-    if arr.len() == 1 && arr[0].shape() == [] {
+    if arr.len() == 1 && arr[0].shape().is_empty() {
         return Ok(arr[0].to_owned());
     }
     let cell_shape = arr
@@ -167,10 +167,8 @@ pub fn c_quote(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
                     y,
                 )
                 .context("dyadic rank drifting"),
-                _ => {
-                    return Err(JError::NonceError)
-                        .with_context(|| anyhow!("can't rank non-nouns, {x:?} {y:?}"))
-                }
+                _ => Err(JError::NonceError)
+                    .with_context(|| anyhow!("can't rank non-nouns, {x:?} {y:?}")),
             }
         }
         _ => bail!("rank conjunction - other options? {x:?}, {u:?}, {v:?}, {y:?}"),

--- a/src/number/number.rs
+++ b/src/number/number.rs
@@ -60,7 +60,7 @@ impl Num {
             // moderately inefficient, but this is mostsly only used on small lists?
             Float(f) => return float_is_int(*f).and_then(|i| Int(i).value_bool()),
             Rational(r) => return r.to_f64().and_then(|f| Float(f).value_bool()),
-            Complex(c) => return complex_is_float(&c).and_then(|f| Float(f).value_bool()),
+            Complex(c) => return complex_is_float(c).and_then(|f| Float(f).value_bool()),
         })
     }
 
@@ -364,11 +364,11 @@ fn promo_ordered((l, r): (Num, Num)) -> (Num, Num) {
         (Bool(l), Bool(r)) => (Int(l.into()), Int(r.into())),
 
         // (bool, int) -> int
-        (Bool(l), Int(r)) => (Int(l.into()), Int(r.into())),
+        (Bool(l), Int(r)) => (Int(l.into()), Int(r)),
 
         // (bool|int, extint) -> extint
-        (Bool(l), ExtInt(r)) => (ExtInt(l.into()), ExtInt(r.into())),
-        (Int(l), ExtInt(r)) => (ExtInt(l.into()), ExtInt(r.into())),
+        (Bool(l), ExtInt(r)) => (ExtInt(l.into()), ExtInt(r)),
+        (Int(l), ExtInt(r)) => (ExtInt(l.into()), ExtInt(r)),
 
         // (bool|int|extint, rational) -> rational
         (Bool(l), Rational(r)) => (rational(l), r.into()),

--- a/src/number/promote.rs
+++ b/src/number/promote.rs
@@ -11,12 +11,12 @@ use crate::error::JError;
 pub fn promote_to_array(parts: Vec<Elem>) -> Result<JArray> {
     // priority table: https://code.jsoftware.com/wiki/Vocabulary/NumericPrecisions#Numeric_Precisions_in_J
     if parts.iter().any(|n| matches!(n, Elem::Boxed(_))) {
-        return arrayise(parts.into_iter().map(|v| match v {
+        arrayise(parts.into_iter().map(|v| match v {
             Elem::Boxed(b) => Ok(b),
             _ => {
                 Err(JError::NonceError).context("TODO: unable to arrayise partially boxed content")
             }
-        }));
+        }))
     } else if parts.iter().any(|n| matches!(n, Elem::Char(_))) {
         arrayise(parts.into_iter().map(|v| match v {
             Elem::Char(c) => Ok(c),

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -121,7 +121,7 @@ fn scan_litstring(sentence: &str) -> Result<(usize, Word)> {
             l,
             Noun(CharArray(ArrayD::from_elem(
                 IxDyn(&[]),
-                s.chars().nth(0).unwrap(),
+                s.chars().next().unwrap(),
             ))),
         ))
     } else {
@@ -179,14 +179,14 @@ fn identify_primitive(sentence: &str) -> usize {
 }
 
 fn str_to_primitive(sentence: &str) -> Result<Option<Word>> {
-    Ok(Some(if let Some(n) = primitive_nouns(&sentence) {
+    Ok(Some(if let Some(n) = primitive_nouns(sentence) {
         n
-    } else if let Some(v) = primitive_verbs(&sentence) {
+    } else if let Some(v) = primitive_verbs(sentence) {
         Word::Verb(sentence.to_string(), v)
     } else if let Some(a) = primitive_adverbs(sentence) {
-        Word::Adverb(sentence.to_string(), a.clone())
+        Word::Adverb(sentence.to_string(), a)
     } else if let Some(c) = primitive_conjunctions(sentence) {
-        Word::Conjunction(sentence.to_string(), c.clone())
+        Word::Conjunction(sentence.to_string(), c)
     } else {
         match sentence {
             "=:" => Word::IsGlobal,

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -143,8 +143,8 @@ impl VerbImpl {
             },
             VerbImpl::Hook { l, r } => match (l.deref(), r.deref()) {
                 (Verb(_, u), Verb(_, v)) => match x {
-                    None => u.exec(Some(&y), &v.exec(None, y)?),
-                    Some(x) => u.exec(Some(&x), &v.exec(None, y)?),
+                    None => u.exec(Some(y), &v.exec(None, y)?),
+                    Some(x) => u.exec(Some(x), &v.exec(None, y)?),
                 },
                 _ => panic!("invalid Hook {:?}", self),
             },

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -153,7 +153,7 @@ pub fn v_head(y: &JArray) -> Result<Word> {
     // ({. 1 2 3) is a different shape to (1 {. 1 2 3)
     match res {
         Noun(a) => {
-            if a.shape().len() > 0 {
+            if !a.shape().is_empty() {
                 let s = &a.shape()[1..];
                 Ok(Noun(JArray::from(a.clone().to_shape(s).unwrap())))
             } else {
@@ -233,7 +233,7 @@ pub fn v_tail(y: &JArray) -> Result<Word> {
     // 3  NB. atom not a single element list
     match res {
         Noun(a) => {
-            if a.shape().len() > 0 {
+            if !a.shape().is_empty() {
                 let s = &a.shape()[1..];
                 Ok(Noun(JArray::from(a.clone().to_shape(s).unwrap())))
             } else {
@@ -288,7 +288,7 @@ pub fn v_drop(x: &JArray, y: &JArray) -> Result<Word> {
                             if new_x < 0 {
                                 todo!("return empty array of type arr")
                             } else {
-                                v_take(&JArray::from(new_x * -1), y)?
+                                v_take(&JArray::from(-new_x), y)?
                             }
                         }
                     })

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -333,7 +333,7 @@ pub fn v_extend_precision(_y: &JArray) -> Result<Word> {
 }
 /// x: (dyad)
 pub fn v_num_denom(x: &JArray, y: &JArray) -> Result<Word> {
-    if x.shape() != [] {
+    if !x.shape().is_empty() {
         return Err(JError::RankError).context("num denum requires atomic x");
     }
     let mode = match x.to_i64() {


### PR DESCRIPTION
Fix all the non-controversial `cargo clippy` results, making the report a bit more readable.