### PR TITLE
feat: passive / reflexive / power / cat / sort / nub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
+ "try-partialord",
  "winit",
 ]
 
@@ -1456,6 +1457,12 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "try-partialord"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494f2baf446447eb9b49ece9bbc391b8b251ceb4778f7362ef09dd9eadec390f"
 
 [[package]]
 name = "ttf-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ordered-float = "3"
 rand = "0.8"
 regex = "1"
 thiserror = "1"
+try-partialord = "0.1"
 
 # examples / test utils
 serde = { version = "1", features = ["derive"] }

--- a/examples/ranky-ranks.rs
+++ b/examples/ranky-ranks.rs
@@ -21,9 +21,8 @@ fn main() -> Result<()> {
         let res = scan_eval(&expr);
         println!("r: {}", format!("{:?}", res).replace('\n', "\n   "));
 
-        let (c, common, spare) =
-            generate_cells(arr(x)?, arr(y)?, (Rank::new(xr)?, Rank::new(yr)?))?;
-        println!("g: {c:?} {common:?} {spare:?}");
+        let (frames, c) = generate_cells(arr(x)?, arr(y)?, (Rank::new(xr)?, Rank::new(yr)?))?;
+        println!("g: {c:?} {frames:?}");
         println!();
     }
     Ok(())

--- a/src/arrays/cow.rs
+++ b/src/arrays/cow.rs
@@ -4,7 +4,7 @@ use ndarray::IntoDimension;
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
-use crate::{JArray, Word};
+use crate::JArray;
 
 pub type CowArrayD<'t, T> = CowArray<'t, T, IxDyn>;
 
@@ -17,7 +17,7 @@ pub enum JArrayCow<'a> {
     RationalArray(CowArrayD<'a, BigRational>),
     FloatArray(CowArrayD<'a, f64>),
     ComplexArray(CowArrayD<'a, Complex64>),
-    BoxArray(CowArrayD<'a, Word>),
+    BoxArray(CowArrayD<'a, JArray>),
 }
 
 macro_rules! impl_array {
@@ -139,7 +139,7 @@ impl_from_atom!(BigInt, JArrayCow::ExtIntArray);
 impl_from_atom!(BigRational, JArrayCow::RationalArray);
 impl_from_atom!(f64, JArrayCow::FloatArray);
 impl_from_atom!(Complex64, JArrayCow::ComplexArray);
-impl_from_atom!(Word, JArrayCow::BoxArray);
+impl_from_atom!(JArray, JArrayCow::BoxArray);
 
 macro_rules! impl_from_nd {
     ($t:ty, $j:path) => {
@@ -158,7 +158,7 @@ impl_from_nd!(BigInt, JArrayCow::ExtIntArray);
 impl_from_nd!(BigRational, JArrayCow::RationalArray);
 impl_from_nd!(f64, JArrayCow::FloatArray);
 impl_from_nd!(Complex64, JArrayCow::ComplexArray);
-impl_from_nd!(Word, JArrayCow::BoxArray);
+impl_from_nd!(JArray, JArrayCow::BoxArray);
 
 macro_rules! impl_from_nd_view {
     ($t:ty, $j:path) => {
@@ -177,4 +177,4 @@ impl_from_nd_view!(BigInt, JArrayCow::ExtIntArray);
 impl_from_nd_view!(BigRational, JArrayCow::RationalArray);
 impl_from_nd_view!(f64, JArrayCow::FloatArray);
 impl_from_nd_view!(Complex64, JArrayCow::ComplexArray);
-impl_from_nd_view!(Word, JArrayCow::BoxArray);
+impl_from_nd_view!(JArray, JArrayCow::BoxArray);

--- a/src/arrays/elem.rs
+++ b/src/arrays/elem.rs
@@ -1,14 +1,14 @@
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
-use crate::arrays::Word;
 use crate::number::Num;
+use crate::JArray;
 
 #[derive(Clone, Debug)]
 pub enum Elem {
     Num(Num),
     Char(char),
-    Boxed(Word),
+    Boxed(JArray),
 }
 
 macro_rules! from_num {
@@ -34,8 +34,8 @@ impl From<char> for Elem {
     }
 }
 
-impl From<Word> for Elem {
-    fn from(value: Word) -> Self {
+impl From<JArray> for Elem {
+    fn from(value: JArray) -> Self {
         Elem::Boxed(value)
     }
 }

--- a/src/arrays/mod.rs
+++ b/src/arrays/mod.rs
@@ -3,6 +3,7 @@
 mod arrayable;
 mod cow;
 mod elem;
+mod nd_ext;
 mod owned;
 mod plural;
 mod word;
@@ -10,7 +11,8 @@ mod word;
 pub use arrayable::Arrayable;
 pub use cow::{CowArrayD, JArrayCow};
 pub use elem::Elem;
-pub use owned::{IntoJArray, JArray};
+pub use nd_ext::map_result;
+pub use owned::{BoxArray, IntoJArray, JArray};
 pub use plural::JArrays;
 pub use word::Word;
 

--- a/src/arrays/nd_ext.rs
+++ b/src/arrays/nd_ext.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+use ndarray::prelude::*;
+
+pub fn map_result<T, U>(arr: ArrayD<T>, f: impl FnMut(T) -> Result<U>) -> Result<ArrayD<U>> {
+    let shape = arr.shape().to_vec();
+    let data = arr.into_iter().map(f).collect::<Result<Vec<U>>>()?;
+    Ok(ArrayD::from_shape_vec(shape, data).expect("just unpacked it"))
+}

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -120,6 +120,18 @@ impl JArray {
         })
     }
 
+    // TODO: Iterator
+    pub fn outer_iter<'v>(&'v self) -> Vec<JArrayCow<'v>> {
+        if self.shape().is_empty() {
+            vec![JArrayCow::from(self)]
+        } else {
+            impl_array!(self, |x: &'v ArrayBase<_, _>| x
+                .outer_iter()
+                .map(JArrayCow::from)
+                .collect())
+        }
+    }
+
     /// rank_iter, but the other way up, and more picky about its arguments
     pub fn dims_iter(&self, dims: usize) -> Vec<JArray> {
         assert!(

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -22,7 +22,7 @@ pub enum JArray {
     RationalArray(ArrayD<BigRational>),
     FloatArray(ArrayD<f64>),
     ComplexArray(ArrayD<Complex64>),
-    BoxArray(ArrayD<Word>),
+    BoxArray(ArrayD<JArray>),
 }
 
 impl fmt::Debug for JArray {
@@ -372,7 +372,7 @@ impl_into_jarray!(ArrayD<BigInt>, JArray::ExtIntArray);
 impl_into_jarray!(ArrayD<BigRational>, JArray::RationalArray);
 impl_into_jarray!(ArrayD<f64>, JArray::FloatArray);
 impl_into_jarray!(ArrayD<Complex64>, JArray::ComplexArray);
-impl_into_jarray!(ArrayD<Word>, JArray::BoxArray);
+impl_into_jarray!(ArrayD<JArray>, JArray::BoxArray);
 
 macro_rules! impl_from_atom {
     ($t:ty, $j:path) => {
@@ -390,7 +390,6 @@ impl_from_atom!(BigInt, JArray::ExtIntArray);
 impl_from_atom!(BigRational, JArray::RationalArray);
 impl_from_atom!(f64, JArray::FloatArray);
 impl_from_atom!(Complex64, JArray::ComplexArray);
-impl_from_atom!(Word, JArray::BoxArray);
 
 macro_rules! impl_from_atom_ref {
     ($t:ty, $j:path) => {
@@ -408,7 +407,7 @@ impl_from_atom_ref!(&BigInt, JArray::ExtIntArray);
 impl_from_atom_ref!(&BigRational, JArray::RationalArray);
 impl_from_atom_ref!(&f64, JArray::FloatArray);
 impl_from_atom_ref!(&Complex64, JArray::ComplexArray);
-impl_from_atom_ref!(&Word, JArray::BoxArray);
+impl_from_atom_ref!(&JArray, JArray::BoxArray);
 
 impl From<Num> for JArray {
     fn from(value: Num) -> Self {

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -13,6 +13,8 @@ use crate::arrays::elem::Elem;
 use crate::number::Num;
 use crate::Word;
 
+pub type BoxArray = ArrayD<JArray>;
+
 #[derive(Clone, PartialEq)]
 pub enum JArray {
     BoolArray(ArrayD<u8>),
@@ -22,7 +24,7 @@ pub enum JArray {
     RationalArray(ArrayD<BigRational>),
     FloatArray(ArrayD<f64>),
     ComplexArray(ArrayD<Complex64>),
-    BoxArray(ArrayD<JArray>),
+    BoxArray(BoxArray),
 }
 
 impl fmt::Debug for JArray {

--- a/src/arrays/plural.rs
+++ b/src/arrays/plural.rs
@@ -3,7 +3,6 @@ use ndarray::prelude::*;
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
-use super::Word;
 use crate::{JArray, JError};
 
 #[derive(Debug)]
@@ -15,7 +14,7 @@ pub enum JArrays<'v> {
     RationalArrays(Vec<ArrayViewD<'v, BigRational>>),
     FloatArrays(Vec<ArrayViewD<'v, f64>>),
     ComplexArrays(Vec<ArrayViewD<'v, Complex64>>),
-    BoxArrays(Vec<ArrayViewD<'v, Word>>),
+    BoxArrays(Vec<ArrayViewD<'v, JArray>>),
 }
 
 macro_rules! homo_array {

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use log::debug;
 use num_traits::Zero;
 
+use crate::arrays::BoxArray;
 use crate::number::{promote_to_array, Num};
 use crate::verbs::{DyadRank, Rank};
 use crate::{Elem, JArray, JError, Word};
@@ -115,7 +116,7 @@ pub fn apply_cells(
         .collect()
 }
 
-pub fn flatten(frames: &[usize], macrocell_results: &[JArray]) -> Result<JArray> {
+pub fn flatten(results: &BoxArray) -> Result<JArray> {
     // TODO: this is only true for dyads, the monads re-use this code ignoring the split
     // TODO: I wonder if really this funciton should be talking a pre-flattened answer,
     // TODO: we don't otherwise care
@@ -129,14 +130,15 @@ pub fn flatten(frames: &[usize], macrocell_results: &[JArray]) -> Result<JArray>
     // }
 
     // max(all results)
-    let target_inner_shape = macrocell_results
+    let target_inner_shape = results
         .iter()
         .map(|x| x.shape())
         .max()
         .expect("non-empty macrocells");
 
     // common_frame + surplus_frame + max(all results)
-    let target_shape = frames
+    let target_shape = results
+        .shape()
         .iter()
         .chain(target_inner_shape.iter())
         .copied()
@@ -144,7 +146,7 @@ pub fn flatten(frames: &[usize], macrocell_results: &[JArray]) -> Result<JArray>
 
     // flatten
     let mut big_daddy: Vec<Elem> = Vec::new();
-    for arr in macrocell_results {
+    for arr in results {
         if arr.shape() == target_inner_shape {
             // TODO: don't clone
 

--- a/src/cells.rs
+++ b/src/cells.rs
@@ -178,8 +178,11 @@ pub fn flatten(
         }
     }
 
-    let nums = promote_to_array(big_daddy)?;
-    Ok(nums.to_shape(target_shape)?.into())
+    let nums = promote_to_array(big_daddy).context("flattening promotion")?;
+    Ok(nums
+        .to_shape(target_shape)
+        .context("flattening output shape")?
+        .into())
 }
 
 #[cfg(test)]

--- a/src/empty.rs
+++ b/src/empty.rs
@@ -2,7 +2,7 @@ use ndarray::prelude::*;
 use num::complex::Complex64;
 use num::{BigInt, BigRational, Zero};
 
-use crate::{JArray, Word};
+use crate::JArray;
 
 pub trait HasEmpty {
     fn empty() -> Self;
@@ -25,7 +25,4 @@ impl_empty!(BigInt, BigInt::zero());
 impl_empty!(BigRational, BigRational::zero());
 impl_empty!(f64, 0.);
 impl_empty!(Complex64, Complex64::zero());
-impl_empty!(
-    Word,
-    Word::Noun(JArray::BoolArray(Array::from_elem(IxDyn(&[0]), 0)))
-);
+impl_empty!(JArray, JArray::BoolArray(Array::from_elem(IxDyn(&[0]), 0)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ fn primitive_conjunctions(sentence: &str) -> Option<ModifierImpl> {
         "\"" => conj("\"", c_quote),
         "`" => conj("`", c_not_implemented),
         "`:" => conj("`:", c_not_implemented),
-        "@" => conj("@", c_not_implemented),
+        "@" => conj("@", c_at),
         "@." => conj("@.", c_not_implemented),
         "@:" => conj("@:", c_not_implemented),
         "&" => conj("&", c_not_implemented),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     use modifiers::*;
     let adverb = |name, f| ModifierImpl::Adverb(SimpleAdverb { name, f });
     Some(match sentence {
-        "~" => adverb("~", a_not_implemented),
+        "~" => adverb("~", a_tilde),
         "/" => adverb("/", a_slash),
         "/." => adverb("/.", a_not_implemented),
         "\\" => adverb("\\", a_not_implemented),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
         "^" => primitive("^", v_exponential, v_power, (0, 0, 0)),
         "^." => primitive("^.", v_natural_log, v_logarithm, (0, 0, 0)),
         "$" => primitive("$", v_shape_of, v_shape, (inf, 1, inf)),
+        "~." => VerbImpl::Primitive(PrimitiveImpl::monad("~.", v_nub)), // inf
         "~:" => primitive("~:", v_nub_sieve, v_not_equal, (inf, 0, 0)),
         "|" => primitive("|", v_magnitude, v_residue, (0, 0, 0)),
         "|." => primitive("|.", v_reverse, v_rotate_shift, (inf, inf, inf)),
@@ -139,7 +140,6 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
         "^!." => not_impl("^!."),
         "$." => not_impl("$."),
         "$:" => not_impl("$:"),
-        "~." => not_impl("~."),
         "|:" => not_impl("|:"),
         ".:" => not_impl(".:"),
         ".." => not_impl(".."),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     Some(match sentence {
         "~" => adverb("~", a_tilde),
         "/" => adverb("/", a_slash),
-        "/." => adverb("/.", a_not_implemented),
+        "/." => adverb("/.", a_slash_dot),
         "\\" => adverb("\\", a_not_implemented),
         "\\." => adverb("\\.", a_not_implemented),
         "]:" => adverb("]:", a_not_implemented),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
         "#." => primitive("#.", v_base_, v_base, (1, 1, 1)),
         "#:" => primitive("#:", v_antibase_, v_antibase, (inf, 1, 0)),
         "!" => primitive("!", v_factorial, v_out_of, (0, 0, 0)),
-        "/:" => primitive("/:", v_grade_up, v_sort, (inf, inf, inf)),
-        "\\:" => primitive("\\:", v_grade_down, v_sort, (inf, inf, inf)),
+        "/:" => primitive("/:", v_grade_up, v_sort_up, (inf, inf, inf)),
+        "\\:" => primitive("\\:", v_grade_down, v_sort_down, (inf, inf, inf)),
 
         "[" => primitive("[", v_same, v_left, (inf, inf, inf)),
         "]" => primitive("]", v_same, v_right, (inf, inf, inf)),

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -28,6 +28,21 @@ pub fn a_not_implemented(_x: Option<&Word>, _u: &Word, _y: &Word) -> Result<Word
     Err(JError::NonceError).context("blanket adverb implementation")
 }
 
+pub fn a_tilde(x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
+    match x {
+        None => match u {
+            Word::Verb(_, u) => u.exec(Some(y), y),
+            _ => Err(JError::DomainError)
+                .with_context(|| anyhow!("expected to ~ a verb, not {:?}", u)),
+        },
+        Some(x) => match u {
+            Word::Verb(_, u) => u.exec(Some(y), x),
+            _ => Err(JError::DomainError)
+                .with_context(|| anyhow!("expected to ~ a verb, not {:?}", u)),
+        },
+    }
+}
+
 pub fn a_slash(x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
     match x {
         None => match u {

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -60,3 +60,12 @@ pub fn a_slash(x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
         Some(_x) => Err(JError::custom("dyadic / not implemented yet")),
     }
 }
+
+pub fn a_slash_dot(x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
+    match (x, y) {
+        // (Some(Word::Noun(x)), Word::Noun(y)) if x.shape().len() == 1 && y.shape().len() == 1 => {
+        //
+        // }
+        _ => Err(JError::NonceError).with_context(|| anyhow!("{x:?} {u:?} /. {y:?}")),
+    }
+}

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -8,8 +8,8 @@ use ndarray::prelude::*;
 use crate::arrays::JArray::*;
 use crate::arrays::JArrays;
 use crate::eval;
-use crate::verbs::{exec_dyad, exec_monad, Rank};
-use crate::{reduce_arrays, HasEmpty, JArray, JError, Word};
+use crate::verbs::{exec_dyad, exec_dyad_inner, exec_monad, exec_monad_inner, Rank, VerbImpl};
+use crate::{flatten, reduce_arrays, HasEmpty, JArray, JError, Word};
 
 pub type ConjunctionFn = fn(Option<&Word>, &Word, &Word, &Word) -> Result<Word>;
 
@@ -148,12 +148,36 @@ pub fn c_quote(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
 }
 
 pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
-    match (u, v) {
-        (Word::Verb(_, u), Word::Verb(_, v)) => {
-            let a = v.exec(x, y).context("first half of @ execution")?;
-            u.exec(None, &a)
+    match (u, v, y) {
+        (Word::Verb(_, u), Word::Verb(_, VerbImpl::Primitive(p)), Word::Noun(y)) => {
+            // this is just v.exec() without flatten, isn't it
+            let (common_frame, surplus_frame, r) = match x {
+                Some(Word::Noun(x)) => {
+                    let dyad = p
+                        .dyad
+                        .ok_or(JError::DomainError)
+                        .context("expecting a dyadic v")?;
+                    exec_dyad_inner(dyad.f, dyad.rank, x, y)?
+                }
+                None => exec_monad_inner(p.monad.f, p.monad.rank, y)?,
+                _ => return Err(JError::NonceError).context("non-word noun"),
+            };
+
+            // then apply u
+            let r = r
+                .into_iter()
+                .flat_map(|v| v)
+                .map(|a| match u.exec(None, &Word::Noun(a.clone()))? {
+                    Word::Noun(arr) => Ok(arr),
+                    _ => Err(JError::NonceError).context("refusing to believe in non-nouns"),
+                })
+                .collect::<Result<Vec<JArray>>>()?;
+
+            // then flatten (fill)
+            Ok(Word::Noun(flatten(&common_frame, &surplus_frame, &[r])?))
         }
-        _ => Err(JError::DomainError).with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
+        _ => Err(JError::DomainError)
+            .with_context(|| anyhow!("expected to @ a primitive verb, not {:?}", u)),
     }
 }
 

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -151,7 +151,7 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
     match (u, v, y) {
         (Word::Verb(_, u), Word::Verb(_, VerbImpl::Primitive(p)), Word::Noun(y)) => {
             // this is just v.exec() without flatten, isn't it
-            let (common_frame, surplus_frame, r) = match x {
+            let (frames, r) = match x {
                 Some(Word::Noun(x)) => {
                     let dyad = p
                         .dyad
@@ -173,7 +173,7 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
                 .collect::<Result<Vec<JArray>>>()?;
 
             // then flatten (fill)
-            Ok(Word::Noun(flatten(&common_frame, &surplus_frame, &r)?))
+            Ok(Word::Noun(flatten(&frames, &r)?))
         }
         _ => Err(JError::DomainError)
             .with_context(|| anyhow!("expected to @ a primitive verb, not {:?}", u)),

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -148,23 +148,12 @@ pub fn c_quote(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
 }
 
 pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
-    match x {
-        None => match (u, v) {
-            (Word::Verb(_, u), Word::Verb(_, v)) => {
-                let a = v.exec(None, y).context("first half of @ execution")?;
-                u.exec(None, &a)
-            }
-            _ => Err(JError::DomainError)
-                .with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
-        },
-        Some(x) => match (u, v) {
-            (Word::Verb(_, u), Word::Verb(_, v)) => {
-                let a = v.exec(Some(x), y).context("first half of @ execution")?;
-                u.exec(None, &a)
-            }
-            _ => Err(JError::DomainError)
-                .with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
-        },
+    match (u, v) {
+        (Word::Verb(_, u), Word::Verb(_, v)) => {
+            let a = v.exec(x, y).context("first half of @ execution")?;
+            u.exec(None, &a)
+        }
+        _ => Err(JError::DomainError).with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
     }
 }
 

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -166,7 +166,6 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
             // then apply u
             let r = r
                 .into_iter()
-                .flat_map(|v| v)
                 .map(|a| match u.exec(None, &Word::Noun(a.clone()))? {
                     Word::Noun(arr) => Ok(arr),
                     _ => Err(JError::NonceError).context("refusing to believe in non-nouns"),
@@ -174,7 +173,7 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
                 .collect::<Result<Vec<JArray>>>()?;
 
             // then flatten (fill)
-            Ok(Word::Noun(flatten(&common_frame, &surplus_frame, &[r])?))
+            Ok(Word::Noun(flatten(&common_frame, &surplus_frame, &r)?))
         }
         _ => Err(JError::DomainError)
             .with_context(|| anyhow!("expected to @ a primitive verb, not {:?}", u)),

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use ndarray::prelude::*;
 
 use crate::arrays::JArray::*;
-use crate::arrays::JArrays;
+use crate::arrays::{map_result, JArrays};
 use crate::eval;
 use crate::verbs::{exec_dyad, exec_dyad_inner, exec_monad, exec_monad_inner, Rank, VerbImpl};
 use crate::{flatten, reduce_arrays, HasEmpty, JArray, JError, Word};
@@ -151,7 +151,7 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
     match (u, v, y) {
         (Word::Verb(_, u), Word::Verb(_, VerbImpl::Primitive(p)), Word::Noun(y)) => {
             // this is just v.exec() without flatten, isn't it
-            let (frames, r) = match x {
+            let r = match x {
                 Some(Word::Noun(x)) => {
                     let dyad = p
                         .dyad
@@ -164,16 +164,13 @@ pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
             };
 
             // then apply u
-            let r = r
-                .into_iter()
-                .map(|a| match u.exec(None, &Word::Noun(a.clone()))? {
-                    Word::Noun(arr) => Ok(arr),
-                    _ => Err(JError::NonceError).context("refusing to believe in non-nouns"),
-                })
-                .collect::<Result<Vec<JArray>>>()?;
+            let r = map_result(r, |a| match u.exec(None, &Word::Noun(a.clone()))? {
+                Word::Noun(arr) => Ok(arr),
+                other => bail!("refusing to believe in non-nouns: {other:?}"),
+            })?;
 
             // then flatten (fill)
-            Ok(Word::Noun(flatten(&frames, &r)?))
+            Ok(Word::Noun(flatten(&r)?))
         }
         _ => Err(JError::DomainError)
             .with_context(|| anyhow!("expected to @ a primitive verb, not {:?}", u)),

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -147,6 +147,27 @@ pub fn c_quote(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
     }
 }
 
+pub fn c_at(x: Option<&Word>, u: &Word, v: &Word, y: &Word) -> Result<Word> {
+    match x {
+        None => match (u, v) {
+            (Word::Verb(_, u), Word::Verb(_, v)) => {
+                let a = v.exec(None, y).context("first half of @ execution")?;
+                u.exec(None, &a)
+            }
+            _ => Err(JError::DomainError)
+                .with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
+        },
+        Some(x) => match (u, v) {
+            (Word::Verb(_, u), Word::Verb(_, v)) => {
+                let a = v.exec(Some(x), y).context("first half of @ execution")?;
+                u.exec(None, &a)
+            }
+            _ => Err(JError::DomainError)
+                .with_context(|| anyhow!("expected to @ a verb, not {:?}", u)),
+        },
+    }
+}
+
 pub fn c_cor(x: Option<&Word>, n: &Word, m: &Word, y: &Word) -> Result<Word> {
     match (n, m) {
         (Word::Noun(IntArray(n)), Word::Noun(CharArray(jcode))) => {

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -119,7 +119,8 @@ impl VerbImpl {
                     exec_dyad(dyad.f, rank.map(|r| (r.1, r.2)).unwrap_or(dyad.rank), x, y)
                         .with_context(|| anyhow!("dyadic {:?}", imp.name))
                 }
-                _ => Err(JError::DomainError).context("primitive on non-nouns"),
+                other => Err(JError::DomainError)
+                    .with_context(|| anyhow!("primitive on non-nouns: {other:#?}")),
             },
             VerbImpl::DerivedVerb { l, r, m } => match (l.deref(), r.deref(), m.deref()) {
                 (u @ Verb(_, _), Nothing, Adverb(_, a)) => a.exec(x, u, &Nothing, y),

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -60,7 +60,7 @@ pub fn exec_monad_inner(
     f: impl Fn(&JArray) -> Result<Word>,
     rank: Rank,
     y: &JArray,
-) -> Result<(Vec<usize>, Vec<usize>, Vec<Vec<JArray>>)> {
+) -> Result<(Vec<usize>, Vec<usize>, Vec<JArray>)> {
     let (cells, common_frame) = monad_cells(y, rank)?;
 
     let results = monad_apply(&cells, |y| {
@@ -70,9 +70,7 @@ pub fn exec_monad_inner(
         })
     })?;
 
-    // TODO: I really don't understand where this double array nesting is coming from,
-    // TODO: nothing seems to care about it.
-    Ok((common_frame, Vec::new(), vec![results]))
+    Ok((common_frame, Vec::new(), results))
 }
 
 pub fn exec_monad(f: impl Fn(&JArray) -> Result<Word>, rank: Rank, y: &JArray) -> Result<Word> {
@@ -90,7 +88,7 @@ pub fn exec_dyad_inner(
     rank: DyadRank,
     x: &JArray,
     y: &JArray,
-) -> Result<(Vec<usize>, Vec<usize>, Vec<Vec<JArray>>)> {
+) -> Result<(Vec<usize>, Vec<usize>, Vec<JArray>)> {
     let (cells, common_frame, surplus_frame) =
         generate_cells(x.clone(), y.clone(), rank).context("generating cells")?;
 

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -60,7 +60,7 @@ pub fn exec_monad_inner(
     f: impl Fn(&JArray) -> Result<Word>,
     rank: Rank,
     y: &JArray,
-) -> Result<(Vec<usize>, Vec<usize>, Vec<JArray>)> {
+) -> Result<(Vec<usize>, Vec<JArray>)> {
     let (cells, common_frame) = monad_cells(y, rank)?;
 
     let results = monad_apply(&cells, |y| {
@@ -70,7 +70,7 @@ pub fn exec_monad_inner(
         })
     })?;
 
-    Ok((common_frame, Vec::new(), results))
+    Ok((common_frame, results))
 }
 
 pub fn exec_monad(f: impl Fn(&JArray) -> Result<Word>, rank: Rank, y: &JArray) -> Result<Word> {
@@ -78,8 +78,8 @@ pub fn exec_monad(f: impl Fn(&JArray) -> Result<Word>, rank: Rank, y: &JArray) -
         return f(y).context("infinite monad shortcut");
     }
 
-    let (common_frame, surplus_frame, application_result) = exec_monad_inner(f, rank, y)?;
-    let flat = flatten(&common_frame, &surplus_frame, &application_result)?;
+    let (frames, application_result) = exec_monad_inner(f, rank, y)?;
+    let flat = flatten(&frames, &application_result)?;
     Ok(Word::Noun(flat))
 }
 
@@ -88,12 +88,11 @@ pub fn exec_dyad_inner(
     rank: DyadRank,
     x: &JArray,
     y: &JArray,
-) -> Result<(Vec<usize>, Vec<usize>, Vec<JArray>)> {
-    let (cells, common_frame, surplus_frame) =
-        generate_cells(x.clone(), y.clone(), rank).context("generating cells")?;
+) -> Result<(Vec<usize>, Vec<JArray>)> {
+    let (frames, cells) = generate_cells(x.clone(), y.clone(), rank).context("generating cells")?;
 
     let application_result = apply_cells(&cells, f, rank).context("applying function to cells")?;
-    Ok((common_frame, surplus_frame, application_result))
+    Ok((frames, application_result))
 }
 
 pub fn exec_dyad(
@@ -106,8 +105,8 @@ pub fn exec_dyad(
         return (f)(x, y).context("infinite dyad shortcut");
     }
 
-    let (common_frame, surplus_frame, application_result) = exec_dyad_inner(f, rank, x, y)?;
-    let flat = flatten(&common_frame, &surplus_frame, &application_result)?;
+    let (frames, application_result) = exec_dyad_inner(f, rank, x, y)?;
+    let flat = flatten(&frames, &application_result)?;
     Ok(Word::Noun(flat))
 }
 

--- a/src/verbs/impl_maths.rs
+++ b/src/verbs/impl_maths.rs
@@ -11,7 +11,7 @@ use crate::{IntoJArray, JArray, JError, Word};
 use anyhow::{Context, Result};
 use ndarray::prelude::*;
 use num::complex::Complex64;
-use num_traits::Zero;
+use num_traits::{FloatConst, Zero};
 use rand::prelude::*;
 
 use super::maff::*;
@@ -285,13 +285,25 @@ pub fn v_root(_x: &JArray, _y: &JArray) -> Result<Word> {
 }
 
 /// ^ (monad)
-pub fn v_exponential(_y: &JArray) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_exponential(y: &JArray) -> Result<Word> {
+    m0nrn(y, |y| {
+        let y = y
+            .approx_f64()
+            .ok_or(JError::NonceError)
+            .context("unable to exponential complexes")?;
+        Ok(f64::E().powf(y).into())
+    })
 }
 
 /// ^ (dyad)
-pub fn v_power(_x: &JArray, _y: &JArray) -> Result<Word> {
-    Err(JError::NonceError.into())
+pub fn v_power(x: &JArray, y: &JArray) -> Result<Word> {
+    rank0(x, y, |x, y| {
+        // TODO: incomplete around complex and return types
+        match (x.approx_f64(), y.approx_f64()) {
+            (Some(x), Some(y)) => Ok(x.powf(y).into()),
+            _ => Err(JError::NonceError).context("unable to power complexes"),
+        }
+    })
 }
 
 /// ^. (monad)

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -38,9 +38,9 @@ where
 
 pub fn atom_aware_box(y: &JArray) -> JArray {
     JArray::BoxArray(if y.shape().is_empty() {
-        arr0d(Word::Noun(y.clone()))
+        arr0d(y.clone())
     } else {
-        array![Word::Noun(y.clone())].into_dyn()
+        array![y.clone()].into_dyn()
     })
 }
 
@@ -53,7 +53,7 @@ pub fn v_box(y: &JArray) -> Result<Word> {
 pub fn v_open(y: &JArray) -> Result<Word> {
     match y {
         JArray::BoxArray(y) => match y.len() {
-            1 => Ok(y.iter().next().expect("just checked").clone()),
+            1 => Ok(Word::Noun(y.iter().next().expect("just checked").clone())),
             _ => bail!("todo: unbox BoxArray"),
         },
         y => Ok(Word::Noun(y.clone())),
@@ -120,7 +120,7 @@ pub fn v_link(x: &JArray, y: &JArray) -> Result<Word> {
             .context("noun")?),
             _ => bail!("invalid types v_semi({:?}, {:?})", x, y),
         },
-        (x, y) => Ok(Word::noun([Word::Noun(x.clone()), Word::Noun(y.clone())])?),
+        (x, y) => Ok(Word::noun([x.clone(), y.clone()])?),
     }
 }
 

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -2,14 +2,14 @@
 
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use std::iter;
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use itertools::Itertools;
 use log::debug;
 use ndarray::prelude::*;
 use ndarray::{concatenate, Axis, Slice};
 
-use crate::number::promote_to_array;
 use crate::{arr0d, impl_array, IntoJArray, JArray, JError, Word};
 
 pub fn reshape<T>(x: &ArrayD<i64>, y: &ArrayD<T>) -> Result<ArrayD<T>>
@@ -124,25 +124,62 @@ pub fn v_link(x: &JArray, y: &JArray) -> Result<Word> {
     }
 }
 
-/// # (dyad)
+/// # (dyad) (1, _)
 pub fn v_copy(x: &JArray, y: &JArray) -> Result<Word> {
-    if x.shape().is_empty() && x.len() == 1 && y.shape().len() == 1 {
-        if let Some(i) = x.to_i64() {
-            let repetitions = i.iter().copied().next().expect("checked");
-            ensure!(repetitions > 0, "unimplemented: {repetitions} repetitions");
-            let mut output = Vec::new();
-            for item in y.clone().into_elems() {
-                for _ in 0..repetitions {
-                    output.push(item.clone());
-                }
-            }
-            Ok(Word::Noun(promote_to_array(output)?))
-        } else {
-            Err(JError::NonceError).context("single-int # list-of-nums only")
-        }
-    } else {
-        Err(JError::NonceError).context("non-atom # non-list")
+    assert!(x.shape().len() <= 1);
+    if x.is_empty() || y.is_empty() {
+        return Err(JError::NonceError).context("empty copy");
     }
+
+    // x is a list of offsets
+    let mut x = x
+        .clone()
+        .into_nums()
+        .ok_or(JError::DomainError)
+        .context("non-numerics as indexes")?
+        .into_iter()
+        .map(|x| x.value_len())
+        .collect::<Option<Vec<usize>>>()
+        .ok_or(JError::DomainError)
+        .context("non-sizes as indexes")?;
+
+    impl_array!(y, |y: &ArrayBase<_, _>| {
+        // y is a list of items
+        let mut y = match y.shape().len() {
+            0 => vec![y.view()],
+            _ => y.outer_iter().collect(),
+        };
+
+        // TODO: treats single-item lists as atoms, like other code, but not like this function, apparently
+        //    (1$1) # 'abc'
+        // |length error
+        match (x.len(), y.len()) {
+            (1, y) => {
+                x = x.into_iter().cycle().take(y).collect();
+            }
+            (x, 1) => {
+                y = y.into_iter().cycle().take(x).collect();
+            }
+            (x, y) if x == y => (),
+            _ => return Err(JError::LengthError).context("unmatched copy arguments"),
+        }
+
+        assert_eq!(x.len(), y.len());
+        let shape = iter::once(0usize)
+            .chain(y[0].shape().iter().copied())
+            .collect_vec();
+
+        let mut output: ArrayD<_> =
+            ArrayD::from_shape_vec(IxDyn(&shape), vec![]).context("template array")?;
+        for (x, y) in x.into_iter().zip(y.into_iter()) {
+            for _ in 0..x {
+                output
+                    .push(Axis(0), y.view())
+                    .with_context(|| anyhow!("push: {y:?})"))?;
+            }
+        }
+        Ok(Word::Noun(output.into_jarray()))
+    })
 }
 
 /// {. (monad)

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -689,6 +689,19 @@ fn test_take_framingfill() -> Result<()> {
 }
 
 #[test]
+fn test_cat() -> Result<()> {
+    assert_eq!(
+        jr::eval(jr::scan("+:@- 7")?, &mut HashMap::new())?,
+        Word::from(-14i64)
+    );
+    assert_eq!(
+        jr::eval(jr::scan("3 +:@- 7")?, &mut HashMap::new())?,
+        Word::from(-8i64)
+    );
+    Ok(())
+}
+
+#[test]
 fn test_tail() -> Result<()> {
     assert_eq!(
         jr::eval(jr::scan("{: 'abc'")?, &mut HashMap::new())?,

--- a/tests/sanity_checks.rs
+++ b/tests/sanity_checks.rs
@@ -440,7 +440,7 @@ fn test_box() {
     let mut names = HashMap::new();
     assert_eq!(
         jr::eval(jr::scan("< 42").unwrap(), &mut names).unwrap(),
-        Word::noun(arr0d(Word::from(42))).unwrap()
+        Word::noun(arr0d(JArray::from(42i64))).unwrap()
     );
 }
 
@@ -477,18 +477,18 @@ fn test_link() {
     assert_eq!(
         jr::eval(jr::scan("1 ; 2 ; 3").unwrap(), &mut names).unwrap(),
         Word::noun([
-            Noun(BoolArray(Array::from_elem(IxDyn(&[]), 1))),
-            Noun(IntArray(Array::from_elem(IxDyn(&[]), 2))),
-            Noun(IntArray(Array::from_elem(IxDyn(&[]), 3))),
+            BoolArray(Array::from_elem(IxDyn(&[]), 1)),
+            IntArray(Array::from_elem(IxDyn(&[]), 2)),
+            IntArray(Array::from_elem(IxDyn(&[]), 3)),
         ])
         .unwrap()
     );
     assert_eq!(
         jr::eval(jr::scan("1 ; 2 ; <3").unwrap(), &mut names).unwrap(),
         Word::noun([
-            Noun(BoolArray(Array::from_elem(IxDyn(&[]), 1))),
-            Noun(IntArray(Array::from_elem(IxDyn(&[]), 2))),
-            Noun(IntArray(Array::from_elem(IxDyn(&[]), 3))),
+            BoolArray(Array::from_elem(IxDyn(&[]), 1)),
+            IntArray(Array::from_elem(IxDyn(&[]), 2)),
+            IntArray(Array::from_elem(IxDyn(&[]), 3)),
         ])
         .unwrap()
     );

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -153,3 +153,14 @@ NB. sqrt
 %:4 9 16
 NB. incorrect precision: %: 625r100
 NB. nonce: %: 5j2
+
+NB. exponential / power
+3^2
+3^3
+9^0.5
+32^1r5
+
+NB. reflexive / passive
+^~ 3
+3.2 %~ 16
+16 %~ 3.2

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -164,3 +164,9 @@ NB. reflexive / passive
 ^~ 3
 3.2 %~ 16
 16 %~ 3.2
+
+NB. sort
+NB. test framework can't handle alphabetic output: 'abcd' /: 4 2 3 1
+7 8 9 10 /: 4 2 3 1
+7 8 9 10 /: 4 2 3
+7 8 9 10 /: 4 2

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -171,6 +171,12 @@ NB. test framework can't handle alphabetic output: 'abcd' /: 4 2 3 1
 7 8 9 10 /: 4 2 3
 7 8 9 10 /: 4 2
 
+NB. self classify
+= i. 3
+= 5 4 3 4 5
+= 3 3 $ i. 6
+= 1
+
 NB. nub
 ~. (3 3 $ 1 2 3 1 2 3 4 5 6)
 ~. 2 3 4 3 2 5 4 1

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -170,3 +170,7 @@ NB. test framework can't handle alphabetic output: 'abcd' /: 4 2 3 1
 7 8 9 10 /: 4 2 3 1
 7 8 9 10 /: 4 2 3
 7 8 9 10 /: 4 2
+
+NB. nub
+~. (3 3 $ 1 2 3 1 2 3 4 5 6)
+~. 2 3 4 3 2 5 4 1

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -98,6 +98,12 @@ __*3j3
 * 0 1
 * 1 2
 
+NB. copy
+2 4 # (2 3 $ 7 8 9 4 5 6)
+2 # 5 6 7
+2 3 # 2
+2 4 # 7j7
+
 NB. length angle
 NB. test framework fails for float comparison: *. 3j4
 NB. test framework fails for float comparison: *. 3j4 5r2

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -18,7 +18,9 @@ fn exec(run: &Run) -> Result<()> {
     let Word::Noun(arr) = us else { bail!("unexpected non-array from eval: {us:?}") };
     let them_shape = run.parse_shape()?;
 
-    let them_data = run.parse_data()?;
+    let them_data = run
+        .parse_data()
+        .with_context(|| anyhow!("interpreting the generated jsoft output: {:?}", run.output))?;
     let us_data = arr
         .clone()
         .into_nums()

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -423,6 +423,24 @@ datatype = 'boolean'
 shape = ''
 
 [[runs]]
+expr = '7 8 9 10 /: 4 2'
+output = '8 7'
+datatype = 'integer'
+shape = '2'
+
+[[runs]]
+expr = '7 8 9 10 /: 4 2 3'
+output = '8 9 7'
+datatype = 'integer'
+shape = '3'
+
+[[runs]]
+expr = '7 8 9 10 /: 4 2 3 1'
+output = '10 8 9 7'
+datatype = 'integer'
+shape = '4'
+
+[[runs]]
 expr = '9^0.5'
 output = '3'
 datatype = 'floating'

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -471,6 +471,38 @@ datatype = 'integer'
 shape = '2'
 
 [[runs]]
+expr = '= 1'
+output = '1'
+datatype = 'boolean'
+shape = '1 1'
+
+[[runs]]
+expr = '= 3 3 $ i. 6'
+output = '''
+1 0 1
+0 1 0'''
+datatype = 'boolean'
+shape = '2 3'
+
+[[runs]]
+expr = '= 5 4 3 4 5'
+output = '''
+1 0 0 0 1
+0 1 0 1 0
+0 0 1 0 0'''
+datatype = 'boolean'
+shape = '3 5'
+
+[[runs]]
+expr = '= i. 3'
+output = '''
+1 0 0
+0 1 0
+0 0 1'''
+datatype = 'boolean'
+shape = '3 3'
+
+[[runs]]
 expr = '>. 4.6 4 _4 _4.6'
 output = '5 4 _4 _4'
 datatype = 'integer'

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -231,6 +231,36 @@ datatype = 'integer'
 shape = ''
 
 [[runs]]
+expr = '2 # 5 6 7'
+output = '5 5 6 6 7 7'
+datatype = 'integer'
+shape = '6'
+
+[[runs]]
+expr = '2 3 # 2'
+output = '2 2 2 2 2'
+datatype = 'integer'
+shape = '5'
+
+[[runs]]
+expr = '2 4 # (2 3 $ 7 8 9 4 5 6)'
+output = '''
+7 8 9
+7 8 9
+4 5 6
+4 5 6
+4 5 6
+4 5 6'''
+datatype = 'integer'
+shape = '6 3'
+
+[[runs]]
+expr = '2 4 # 7j7'
+output = '7j7 7j7 7j7 7j7 7j7 7j7'
+datatype = 'complex'
+shape = '6'
+
+[[runs]]
 expr = '2-0.5'
 output = '1.5'
 datatype = 'floating'

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -547,3 +547,17 @@ expr = 'j. i. 5'
 output = '0 0j1 0j2 0j3 0j4'
 datatype = 'complex'
 shape = '5'
+
+[[runs]]
+expr = '~. (3 3 $ 1 2 3 1 2 3 4 5 6)'
+output = '''
+1 2 3
+4 5 6'''
+datatype = 'integer'
+shape = '2 3'
+
+[[runs]]
+expr = '~. 2 3 4 3 2 5 4 1'
+output = '2 3 4 5 1'
+datatype = 'integer'
+shape = '5'

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -207,6 +207,12 @@ datatype = 'integer'
 shape = ''
 
 [[runs]]
+expr = '16 %~ 3.2'
+output = '0.2'
+datatype = 'floating'
+shape = ''
+
+[[runs]]
 expr = '1r2'
 output = '1r2'
 datatype = 'rational'
@@ -291,6 +297,12 @@ datatype = 'floating'
 shape = ''
 
 [[runs]]
+expr = '3.2 %~ 16'
+output = '5'
+datatype = 'floating'
+shape = ''
+
+[[runs]]
 expr = '3.2 < 5.1'
 output = '1'
 datatype = 'boolean'
@@ -309,10 +321,28 @@ datatype = 'floating'
 shape = ''
 
 [[runs]]
+expr = '32^1r5'
+output = '2'
+datatype = 'floating'
+shape = ''
+
+[[runs]]
 expr = '3>.4 _4'
 output = '4 3'
 datatype = 'integer'
 shape = '2'
+
+[[runs]]
+expr = '3^2'
+output = '9'
+datatype = 'floating'
+shape = ''
+
+[[runs]]
+expr = '3^3'
+output = '27'
+datatype = 'floating'
+shape = ''
 
 [[runs]]
 expr = '3e1'
@@ -393,6 +423,12 @@ datatype = 'boolean'
 shape = ''
 
 [[runs]]
+expr = '9^0.5'
+output = '3'
+datatype = 'floating'
+shape = ''
+
+[[runs]]
 expr = '<. 4.6 4 _4 _4.6'
 output = '4 4 _4 _5'
 datatype = 'integer'
@@ -433,6 +469,12 @@ expr = '>: 2 3 5 7'
 output = '3 4 6 8'
 datatype = 'integer'
 shape = '4'
+
+[[runs]]
+expr = '^~ 3'
+output = '27'
+datatype = 'floating'
+shape = ''
 
 [[runs]]
 expr = '_'


### PR DESCRIPTION
I was trying to get `#/.~@/:~` to work. How hard can it be. It's EIGHT FUCKING CHARACTERS. FUCK ME.

We're about 10% of the way to an almost-working `/.`, which requires monad `=`, which requires monad `~.`, then the rest of the expression relies on `/:` being implemented on chars, which I haven't done.

--

Expedition notes, day 4, I think `=` and `~.` work, and I've beefed up (dyadic) `#`.

`(= 5 4 3 4 5) #@# 5 4 3 4 5` still won't behave (this is roughly what `#/.~` is trying to achieve, I think).

--

Expedition notes, day 6.

We found more of those impossibly bizarre hieroglyphs scratched into a wall:

https://code.jsoftware.com/wiki/File:Funcomp.png

With the assistance of two cute priests, we have managed to make a more complete attempt at `c_at`, but the code around ranks is now creaking more than before.