### PR TITLE
chore: test framework works based off the binary encoding

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,3 @@
 gen-smoke:
-  rm tests/smoke.toml
+  rm -f tests/smoke.toml
   <tests/smoke.ijs PATH=$PATH:~/ins/j903 cargo run -q --example gen-runlist tests/smoke.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub use crate::eval::eval;
 pub use scan::{scan, scan_with_locations};
 
 // TODO: helper function for tests, not really public
+pub use crate::arrays::Arrayable;
 pub use crate::cells::generate_cells;
 pub use crate::eval::resolve_names;
 pub use crate::modifiers::collect_nouns;

--- a/src/test_impls/jsoft_binary.rs
+++ b/src/test_impls/jsoft_binary.rs
@@ -1,0 +1,238 @@
+use std::collections::HashMap;
+use std::mem::transmute;
+
+use crate::JArray;
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use itertools::Itertools;
+use ndarray::{ArrayD, IxDyn};
+use num::complex::Complex64;
+use num::{BigInt, BigRational};
+
+// https://www.jsoftware.com/help/dictionary/dx003.htm
+#[derive(Copy, Clone, Debug)]
+enum JKind {
+    Bool,
+    Lit,
+    Int,
+    Float,
+    Complex,
+    Boxed,
+    ExtInt,
+    Rational,
+    Symbol,
+    Lit2,
+    Lit4,
+}
+
+impl TryFrom<u64> for JKind {
+    type Error = anyhow::Error;
+    fn try_from(value: u64) -> Result<Self> {
+        use JKind::*;
+        Ok(match value {
+            1 => Bool,
+            2 => Lit,
+            4 => Int,
+            8 => Float,
+            16 => Complex,
+            32 => Boxed,
+            64 => ExtInt,
+            128 => Rational,
+            1024 | 2048 | 4096 | 8192 | 16384 | 32768 => bail!("unsupported: sparse"),
+            65536 => Symbol,
+            131072 => Lit2,
+            262144 => Lit4,
+            other => bail!("unknown: {other}"),
+        })
+    }
+}
+
+impl JKind {
+    fn element_slots(&self, elements: usize) -> Result<usize> {
+        use JKind::*;
+        Ok(match self {
+            Bool => elements / 8 + 1,
+            Complex => elements * 2,
+            Int | Float => elements * 1,
+            Boxed => elements * 1,
+            ExtInt => elements * 1,
+            Rational => elements * 2,
+            other => bail!("unknown size: {other:?}"),
+        })
+    }
+
+    fn stored_by_ref(&self) -> Result<bool> {
+        use JKind::*;
+        Ok(match self {
+            Bool | Int | Float | Complex => false,
+            Boxed | ExtInt | Rational => true,
+            other => bail!("unknown ref: {other:?}"),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Block {
+    kind: JKind,
+    shape: Vec<usize>,
+    elements: usize,
+    data: Vec<u64>,
+}
+
+pub fn parse_hex(x: &str) -> Result<u64> {
+    u64::from_str_radix(x, 16)
+        .with_context(|| anyhow!("{x:?}"))
+        .map(u64::swap_bytes)
+}
+
+// https://www.jsoftware.com/help/dictionary/dx003.htm#:~:text=Convert%20to%20Binary%20Representation
+pub fn decode(lines: &[u64]) -> Result<JArray> {
+    let mut lines = lines.into_iter().copied().enumerate();
+    let mut blocks = HashMap::new();
+
+    while let Some((pos, marker)) = lines.next() {
+        match marker {
+            0xe3 => (),
+            0xe0 | 0xe1 | 0xe2 => bail!("unsupported machine type (or parser error) at {pos}"),
+            other => {
+                bail!("invalid record header {other} at {pos}, probably a parser bug: {blocks:?}")
+            }
+        }
+        blocks.insert(
+            pos,
+            parse_block(&mut lines).with_context(|| anyhow!("block at {pos}"))?,
+        );
+    }
+
+    println!("{blocks:?}");
+
+    let zero = blocks
+        .get(&0)
+        .ok_or_else(|| anyhow!("empty output isn't allowed"))?;
+
+    reconstitute(zero, 0, &blocks)
+}
+
+fn reconstitute(block: &Block, our_off: usize, blocks: &HashMap<usize, Block>) -> Result<JArray> {
+    if !(block.kind.stored_by_ref()?) {
+        return Ok(match block.kind {
+            JKind::Bool => JArray::BoolArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                block
+                    .data
+                    .iter()
+                    .flat_map(|v| v.to_le_bytes())
+                    .take(block.elements)
+                    .collect(),
+            )?),
+            JKind::Int => JArray::IntArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                block
+                    .data
+                    .iter()
+                    .map(|&v| unsafe { transmute(v) })
+                    .collect(),
+            )?),
+            JKind::Float => JArray::FloatArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                block
+                    .data
+                    .iter()
+                    .map(|&v| unsafe { transmute(v) })
+                    .collect(),
+            )?),
+            JKind::Complex => JArray::ComplexArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                block
+                    .data
+                    .iter()
+                    .tuples()
+                    .map(|(&r, &i)| unsafe { Complex64::new(transmute(r), transmute(i)) })
+                    .collect(),
+            )?),
+            other => bail!("unsupported plain type: {other:?}"),
+        });
+    }
+    let mut parts = Vec::new();
+    for sub in &block.data {
+        let off = usize::try_from(sub / 8)? + our_off;
+        let sub = blocks
+            .get(&off)
+            .ok_or_else(|| anyhow!("invalid block references: {sub}"))?;
+        parts.push(reconstitute(sub, off, blocks).context("pulling sub block")?);
+    }
+    Ok(match block.kind {
+        JKind::Boxed => JArray::BoxArray(ArrayD::from_shape_vec(IxDyn(&block.shape), parts)?),
+        JKind::ExtInt => {
+            let parts = parts
+                .into_iter()
+                .map(|p| match p {
+                    JArray::IntArray(x) if x.shape().len() == 1 => Ok(x),
+                    other => bail!("unexpected non-linear part in extint: {other:?}"),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            JArray::ExtIntArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                parts.into_iter().map(big).collect::<Result<Vec<_>>>()?,
+            )?)
+        }
+        JKind::Rational => {
+            let parts = parts
+                .into_iter()
+                .map(|p| match p {
+                    JArray::IntArray(x) if x.shape().len() == 1 => Ok(x),
+                    other => bail!("unexpected non-linear part in extint: {other:?}"),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            JArray::RationalArray(ArrayD::from_shape_vec(
+                IxDyn(&block.shape),
+                parts
+                    .into_iter()
+                    .tuples()
+                    .map(|(up, down)| Ok(BigRational::new(big(up)?, big(down)?)))
+                    .collect::<Result<Vec<_>>>()?,
+            )?)
+        }
+        other => bail!("unsupported ref type: {other:?}"),
+    })
+}
+
+fn big(words: ArrayD<i64>) -> Result<BigInt> {
+    ensure!(words.shape().len() == 1);
+    if words.len() == 1 {
+        Ok(words[0].into())
+    } else {
+        bail!("don't know how to unpack {words:?} into bigint")
+    }
+}
+
+fn parse_block(lines: &mut impl Iterator<Item = (usize, u64)>) -> Result<Block> {
+    let mut lines = lines.map(|(_, x)| x);
+    let kind = JKind::try_from(lines.next().ok_or_else(|| anyhow!("expecting kind"))?)?;
+    let elements = lines.next().ok_or_else(|| anyhow!("expecting elements"))?;
+    let elements = usize::try_from(elements).context("elements didn't fit in a usize")?;
+    let rank = lines.next().ok_or_else(|| anyhow!("expecting rank"))?;
+    let mut shape = Vec::new();
+    for _ in 0..rank {
+        let part = lines
+            .next()
+            .ok_or_else(|| anyhow!("expecting shape part"))?;
+        shape.push(usize::try_from(part)?);
+    }
+
+    Ok(Block {
+        kind,
+        shape,
+        elements,
+        data: lines.take(kind.element_slots(elements)?).collect(),
+    })
+}
+
+#[test]
+fn floats() {
+    let i = parse_hex("000000000000f8bf").unwrap();
+    assert_eq!(-1.5, unsafe { std::mem::transmute(i) });
+
+    let i = parse_hex("333333333333c33f").unwrap();
+    assert_eq!(i, 4594572339843380019);
+    assert_eq!(0.15, unsafe { std::mem::transmute(i) });
+}

--- a/src/test_impls/mod.rs
+++ b/src/test_impls/mod.rs
@@ -1,3 +1,4 @@
+mod jsoft_binary;
 mod jsoft_runs;
 
 use std::collections::HashMap;

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -120,7 +120,7 @@ pub fn v_link(x: &JArray, y: &JArray) -> Result<JArray> {
             .into_array()
             .context("noun")?
             .into_jarray()),
-            _ => bail!("invalid types v_semi({:?}, {:?})", x, y),
+            _ => bail!("invalid types v_link({:?}, {:?})", x, y),
         },
         (x, y) => Ok([x.clone(), y.clone()].into_array()?.into_jarray()),
     }

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -6,6 +6,21 @@ NB. So, edit this file, run `just`, then run `cargo test`, then come back here a
 NB. literal conversions
 0
 1
+0 0
+0 1
+0 1 0
+0 1 0 1
+0 1 0 1 0
+0 1 0 1 0 1
+0 1 0 1 0 1 0
+0 1 0 1 0 1 0 1
+0 1 0 1 0 1 0 1 0
+0 1 0 1 0 1 0 1 0 1
+0 1 0 1 0 1 0 1 0 1 0
+0 1 0 1 0 1 0 1 0 1 0 1
+0 1 0 1 0 1 0 1 0 1 0 1 0
+0 1 0 1 0 1 0 1 0 1 0 1 0 1
+0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
 2
 0.5
 1r2
@@ -18,6 +33,9 @@ __j__
 _j_
 _3j_3.3
 3e1
+0x 1x
+<1
+<2
 
 NB. literal promotions
 1 0.5 2j3
@@ -141,7 +159,7 @@ NB. reciprocal
 NB. incorrect datatype: % 1
 % 0.25
 % 0
-% 6j2
+NB. test framework can't cope with float maths: % 0.2j0.4
 
 NB. incorrect datatype: 3 % 5
 3.2 % 1.6
@@ -182,6 +200,7 @@ NB. self classify
 = 5 4 3 4 5
 = 3 3 $ i. 6
 = 1
+= 'do what you want because a pirate is free, yar har diddledee dee'
 
 NB. nub
 ~. (3 3 $ 1 2 3 1 2 3 4 5 6)

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use jr::test_impls::{scan_eval, Run, RunList};
-use jr::{JArray, Word};
+use jr::Word;
 
 #[test]
 fn smoke() -> Result<()> {
@@ -14,51 +14,13 @@ fn smoke() -> Result<()> {
 }
 
 fn exec(run: &Run) -> Result<()> {
+    let them = run.parse_encoded().context("rehydrating j output")?;
     let us = scan_eval(&run.expr).context("running expression in smoke test")?;
     let Word::Noun(arr) = us else { bail!("unexpected non-array from eval: {us:?}") };
-    let them_shape = run.parse_shape()?;
 
-    let them_data = run
-        .parse_data()
-        .with_context(|| anyhow!("interpreting the generated jsoft output: {:?}", run.output))?;
-    let us_data = arr
-        .clone()
-        .into_nums()
-        .ok_or_else(|| anyhow!("not handling non-num results"))?;
-    if us_data != them_data {
-        bail!(
-            "incorrect data, we got {:?}, they expect {:?}",
-            us_data,
-            them_data
-        );
+    if arr == them {
+        return Ok(());
     }
 
-    if arr.shape() != them_shape {
-        bail!(
-            "incorrect shape, we got {:?}, they expect {:?}",
-            arr.shape(),
-            them_shape
-        );
-    }
-
-    let our_type = match arr {
-        JArray::IntArray(_) => "integer",
-        JArray::BoolArray(_) => "boolean",
-        JArray::CharArray(_) => "character",
-        JArray::ExtIntArray(_) => "extended",
-        JArray::RationalArray(_) => "rational",
-        JArray::FloatArray(_) => "floating",
-        JArray::ComplexArray(_) => "complex",
-        JArray::BoxArray(_) => "box",
-    };
-
-    if our_type != run.datatype {
-        bail!(
-            "incorrect datatype, we got {:?}, they expect {:?}",
-            our_type,
-            run.datatype
-        );
-    }
-
-    Ok(())
+    Err(anyhow!("incorrect data, we got:\n{arr:?}\n\nThey expect:\n{them:?}\n\njsoft would render this like this:\n{}", run.output))
 }

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -1,92 +1,72 @@
 [[runs]]
 expr = "#/.~@/:~'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'"
 output = '20 12 17 21'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,14,0c,11,15'
 
 [[runs]]
 expr = '% 0'
 output = '_'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000f07f'
 
 [[runs]]
 expr = '% 0.25'
 output = '4'
-datatype = 'floating'
-shape = ''
-
-[[runs]]
-expr = '% 6j2'
-output = '0.15j_0.05'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,08,01,,000000000000104'
 
 [[runs]]
 expr = '%:-1'
 output = '0j1'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,,000000000000f03f'
 
 [[runs]]
 expr = '%:-4'
 output = '0j2'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,,000000000000004'
 
 [[runs]]
 expr = '%:4 9 16'
 output = '2 3 4'
-datatype = 'floating'
-shape = '3'
+encoded = 'e3,08,03,01,03,000000000000004,000000000000084,000000000000104'
 
 [[runs]]
 expr = '(0 1j2 2j4 3j6 4j8) * (+(0 1j2 2j4 3j6 4j8))'
 output = '0 5 20 45 80'
-datatype = 'complex'
-shape = '5'
+encoded = 'e3,1,05,01,05,,,000000000000144,,000000000000344,,000000000080464,,000000000000544,'
 
 [[runs]]
 expr = '(i. 5) + 2 * j. (i. 5)'
 output = '0 1j2 2j4 3j6 4j8'
-datatype = 'complex'
-shape = '5'
+encoded = 'e3,1,05,01,05,,,000000000000f03f,000000000000004,000000000000004,000000000000104,000000000000084,000000000000184,000000000000104,000000000000204'
 
 [[runs]]
 expr = '* 0 1'
 output = '0 1'
-datatype = 'boolean'
-shape = '2'
+encoded = 'e3,01,02,01,02,0001'
 
 [[runs]]
 expr = '* 1 2'
 output = '1 1'
-datatype = 'integer'
-shape = '2'
+encoded = 'e3,04,02,01,02,01,01'
 
 [[runs]]
 expr = '* _4 0 4'
 output = '_1 0 1'
-datatype = 'integer'
-shape = '3'
+encoded = 'e3,04,03,01,03,ffffffffffffffff,,01'
 
 [[runs]]
 expr = '*: 2 3 4'
 output = '4 9 16'
-datatype = 'integer'
-shape = '3'
+encoded = 'e3,04,03,01,03,04,09,1'
 
 [[runs]]
 expr = '*: 2.1 4.3'
 output = '4.41 18.49'
-datatype = 'floating'
-shape = '2'
+encoded = 'e3,08,02,01,02,a4703d0ad7a3114,3d0ad7a3707d324'
 
 [[runs]]
 expr = '+ (i. 5) + 2 * j. (i. 5)'
 output = '0 1j_2 2j_4 3j_6 4j_8'
-datatype = 'complex'
-shape = '5'
+encoded = 'e3,1,05,01,05,,000000000000008,000000000000f03f,00000000000000c,000000000000004,00000000000010c,000000000000084,00000000000018c,000000000000104,00000000000020c'
 
 [[runs]]
 expr = '+. 0 1j2 2j4 3j6'
@@ -95,158 +75,212 @@ output = '''
 1 2
 2 4
 3 6'''
-datatype = 'floating'
-shape = '4 2'
+encoded = 'e3,08,08,02,04,02,,,000000000000f03f,000000000000004,000000000000004,000000000000104,000000000000084,000000000000184'
 
 [[runs]]
 expr = '+: 3 0 _2'
 output = '6 0 _4'
-datatype = 'integer'
-shape = '3'
+encoded = 'e3,04,03,01,03,06,,fcffffffffffffff'
 
 [[runs]]
 expr = '-. 0'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '-. 1'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '-. 2'
 output = '_1'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,ffffffffffffffff'
 
 [[runs]]
 expr = '-. 3j5 1'
 output = '_2j_5 0'
-datatype = 'complex'
-shape = '2'
+encoded = 'e3,1,02,01,02,00000000000000c,00000000000014c,,'
 
 [[runs]]
 expr = '-. 3r2 7'
 output = '_1r2 _6'
-datatype = 'rational'
-shape = '2'
+encoded = 'e3,8,02,01,02,48,78,a8,d8,e3,04,01,01,01,ffffffffffffffff,e3,04,01,01,01,02,e3,04,01,01,01,faffffffffffffff,e3,04,01,01,01,01'
 
 [[runs]]
 expr = '-2 0 _2'
 output = '_2 0 2'
-datatype = 'integer'
-shape = '3'
+encoded = 'e3,04,03,01,03,feffffffffffffff,,02'
 
 [[runs]]
 expr = '0'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '0 *: 0'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '0 *: 1'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
+
+[[runs]]
+expr = '0 0'
+output = '0 0'
+encoded = 'e3,01,02,01,02,'
+
+[[runs]]
+expr = '0 1'
+output = '0 1'
+encoded = 'e3,01,02,01,02,0001'
+
+[[runs]]
+expr = '0 1 0'
+output = '0 1 0'
+encoded = 'e3,01,03,01,03,0001'
+
+[[runs]]
+expr = '0 1 0 1'
+output = '0 1 0 1'
+encoded = 'e3,01,04,01,04,00010001'
+
+[[runs]]
+expr = '0 1 0 1 0'
+output = '0 1 0 1 0'
+encoded = 'e3,01,05,01,05,00010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1'
+output = '0 1 0 1 0 1'
+encoded = 'e3,01,06,01,06,000100010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0'
+output = '0 1 0 1 0 1 0'
+encoded = 'e3,01,07,01,07,000100010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1'
+output = '0 1 0 1 0 1 0 1'
+encoded = 'e3,01,08,01,08,0001000100010001,'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0'
+output = '0 1 0 1 0 1 0 1 0'
+encoded = 'e3,01,09,01,09,0001000100010001,'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1'
+output = '0 1 0 1 0 1 0 1 0 1'
+encoded = 'e3,01,0a,01,0a,0001000100010001,0001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1 0'
+output = '0 1 0 1 0 1 0 1 0 1 0'
+encoded = 'e3,01,0b,01,0b,0001000100010001,0001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1 0 1'
+output = '0 1 0 1 0 1 0 1 0 1 0 1'
+encoded = 'e3,01,0c,01,0c,0001000100010001,00010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1 0 1 0'
+output = '0 1 0 1 0 1 0 1 0 1 0 1 0'
+encoded = 'e3,01,0d,01,0d,0001000100010001,00010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1 0 1 0 1'
+output = '0 1 0 1 0 1 0 1 0 1 0 1 0 1'
+encoded = 'e3,01,0e,01,0e,0001000100010001,000100010001'
+
+[[runs]]
+expr = '0 1 0 1 0 1 0 1 0 1 0 1 0 1 0'
+output = '0 1 0 1 0 1 0 1 0 1 0 1 0 1 0'
+encoded = 'e3,01,0f,01,0f,0001000100010001,000100010001'
 
 [[runs]]
 expr = '0.5'
 output = '0.5'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000e03f'
 
 [[runs]]
 expr = '0x'
 output = '0'
-datatype = 'extended'
-shape = ''
+encoded = 'e3,4,01,,28,e3,04,01,01,01,'
+
+[[runs]]
+expr = '0x 1x'
+output = '0 1'
+encoded = 'e3,4,02,01,02,38,68,e3,04,01,01,01,,e3,04,01,01,01,01'
 
 [[runs]]
 expr = '1'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '1 *: 0'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '1 *: 1'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '1 0.5 2j3'
 output = '1 0.5 2j3'
-datatype = 'complex'
-shape = '3'
+encoded = 'e3,1,03,01,03,000000000000f03f,,000000000000e03f,,000000000000004,000000000000084'
 
 [[runs]]
 expr = '1 2 3 4 5  >  5 4 3 2 1'
 output = '0 0 0 1 1'
-datatype = 'boolean'
-shape = '5'
+encoded = 'e3,01,05,01,05,0000000101'
 
 [[runs]]
 expr = '1 4j2 3j3 2.00'
 output = '1 4j2 3j3 2'
-datatype = 'complex'
-shape = '4'
+encoded = 'e3,1,04,01,04,000000000000f03f,,000000000000104,000000000000004,000000000000084,000000000000084,000000000000004,'
 
 [[runs]]
 expr = '1-0'
 output = '1'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,01'
 
 [[runs]]
 expr = '16 %~ 3.2'
 output = '0.2'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,9a9999999999c93f'
 
 [[runs]]
 expr = '1r2'
 output = '1r2'
-datatype = 'rational'
-shape = ''
+encoded = 'e3,8,01,,3,6,e3,04,01,01,01,01,e3,04,01,01,01,02'
 
 [[runs]]
 expr = '1x'
 output = '1'
-datatype = 'extended'
-shape = ''
+encoded = 'e3,4,01,,28,e3,04,01,01,01,01'
 
 [[runs]]
 expr = '2'
 output = '2'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,02'
 
 [[runs]]
 expr = '2 # 5 6 7'
 output = '5 5 6 6 7 7'
-datatype = 'integer'
-shape = '6'
+encoded = 'e3,04,06,01,06,05,05,06,06,07,07'
 
 [[runs]]
 expr = '2 3 # 2'
 output = '2 2 2 2 2'
-datatype = 'integer'
-shape = '5'
+encoded = 'e3,04,05,01,05,02,02,02,02,02'
 
 [[runs]]
 expr = '2 4 # (2 3 $ 7 8 9 4 5 6)'
@@ -257,268 +291,265 @@ output = '''
 4 5 6
 4 5 6
 4 5 6'''
-datatype = 'integer'
-shape = '6 3'
+encoded = 'e3,04,12,02,06,03,07,08,09,07,08,09,04,05,06,04,05,06,04,05,06,04,05,06'
 
 [[runs]]
 expr = '2 4 # 7j7'
 output = '7j7 7j7 7j7 7j7 7j7 7j7'
-datatype = 'complex'
-shape = '6'
+encoded = 'e3,1,06,01,06,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4,0000000000001c4'
 
 [[runs]]
 expr = '2-0.5'
 output = '1.5'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000f83f'
 
 [[runs]]
 expr = '2-2'
 output = '0'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,'
 
 [[runs]]
 expr = '2-3'
 output = '_1'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,ffffffffffffffff'
 
 [[runs]]
 expr = '2.1j3.1'
 output = '2.1j3.1'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,cdcccccccccc004,cdcccccccccc084'
 
 [[runs]]
 expr = '2j3'
 output = '2j3'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,000000000000004,000000000000084'
 
 [[runs]]
 expr = '2x'
 output = '2'
-datatype = 'extended'
-shape = ''
+encoded = 'e3,4,01,,28,e3,04,01,01,01,02'
 
 [[runs]]
 expr = '3 < 5'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '3 <. 4 _4'
 output = '3 _4'
-datatype = 'integer'
-shape = '2'
+encoded = 'e3,04,02,01,02,03,fcffffffffffffff'
 
 [[runs]]
 expr = '3 = 5'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '3*5'
 output = '15'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,0f'
 
 [[runs]]
 expr = '3.2 % 1.6'
 output = '2'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000004'
 
 [[runs]]
 expr = '3.2 %~ 16'
 output = '5'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000144'
 
 [[runs]]
 expr = '3.2 < 5.1'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '3.2*5'
 output = '16'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000304'
 
 [[runs]]
 expr = '3.2*5r2'
 output = '8'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000204'
 
 [[runs]]
 expr = '32^1r5'
 output = '2'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000004'
 
 [[runs]]
 expr = '3>.4 _4'
 output = '4 3'
-datatype = 'integer'
-shape = '2'
+encoded = 'e3,04,02,01,02,04,03'
 
 [[runs]]
 expr = '3^2'
 output = '9'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000224'
 
 [[runs]]
 expr = '3^3'
 output = '27'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,0000000000003b4'
 
 [[runs]]
 expr = '3e1'
 output = '30'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,1e'
 
 [[runs]]
 expr = '3j4 * 3j_4'
 output = '25'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,000000000000394,'
 
 [[runs]]
 expr = '3r4 % 2'
 output = '3r8'
-datatype = 'rational'
-shape = ''
+encoded = 'e3,8,01,,3,6,e3,04,01,01,01,03,e3,04,01,01,01,08'
 
 [[runs]]
 expr = '3r4 % 5r12'
 output = '9r5'
-datatype = 'rational'
-shape = ''
+encoded = 'e3,8,01,,3,6,e3,04,01,01,01,09,e3,04,01,01,01,05'
 
 [[runs]]
 expr = '3r4 % 7.5'
 output = '0.1'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,9a9999999999b93f'
 
 [[runs]]
 expr = '5 < 37r2'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5 < 5r2'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '5 = 5'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5.1 = 5.1'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5j0 = 5'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5j5 = 5j5'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5r2 = 2.5'
 output = '1'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,01'
 
 [[runs]]
 expr = '5r3 = 2'
 output = '0'
-datatype = 'boolean'
-shape = ''
+encoded = 'e3,01,01,,'
 
 [[runs]]
 expr = '7 8 9 10 /: 4 2'
 output = '8 7'
-datatype = 'integer'
-shape = '2'
+encoded = 'e3,04,02,01,02,08,07'
 
 [[runs]]
 expr = '7 8 9 10 /: 4 2 3'
 output = '8 9 7'
-datatype = 'integer'
-shape = '3'
+encoded = 'e3,04,03,01,03,08,09,07'
 
 [[runs]]
 expr = '7 8 9 10 /: 4 2 3 1'
 output = '10 8 9 7'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,0a,08,09,07'
 
 [[runs]]
 expr = '9^0.5'
 output = '3'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000084'
 
 [[runs]]
 expr = '<. 4.6 4 _4 _4.6'
 output = '4 4 _4 _5'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,04,04,fcffffffffffffff,fbffffffffffffff'
 
 [[runs]]
 expr = '<./7 8 5 9 2'
 output = '2'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,02'
+
+[[runs]]
+expr = '<1'
+output = '''
+┌─┐
+│1│
+└─┘'''
+encoded = 'e3,2,01,,28,e3,01,01,,01'
+
+[[runs]]
+expr = '<2'
+output = '''
+┌─┐
+│2│
+└─┘'''
+encoded = 'e3,2,01,,28,e3,04,01,,02'
 
 [[runs]]
 expr = '<: 2 3 5 7'
 output = '1 2 4 6'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,01,02,04,06'
 
 [[runs]]
 expr = '<: 3 2'
 output = '2 1'
-datatype = 'integer'
-shape = '2'
+encoded = 'e3,04,02,01,02,02,01'
+
+[[runs]]
+expr = "= 'do what you want because a pirate is free, yar har diddledee dee'"
+output = '''
+1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 0 1 0 0 0 1 0 0
+0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 1 0 0 0 0 1 0 0 0 1 0 0 0 0 1 0 0 0 0 0 0 0 1 0 1 0 0 0 0 0 0 1 0 0 1 0 0 0 0 0 1 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 1 0 0 0
+0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1 0 0 1 1
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0'''
+encoded = 'e3,01,0005,02,14,4,01,,,,,,00000001000101,000100000001,0001,0001,,,,,,,0000010000000001,00000001,01,010001,0001000001,00000100000001,000001,0000000001,00000001,0000000001,,,,,,,0000000001,,,,,0000000000000001,,,000000000001,000000000001,0000000001,00010000000001,,0000000001,01,,00000000000001,0000000000000001,,0000000000000001,,,,,,01,,,,00000001,,,,000001,000000000001,,,,,,,00000000000001,,,,,,,,,0001,,,,,,,,0000010000000001,,0100000000000001,01,,0100010100000101,,,00000001,,,,,,,,00000000000001,,00000001,,,,,,,00000001,,,,,,,,0000000001,000001,,0000000001,,,,,000000000001,00000000000001,000000000001,0001,,,,,,000000000001,,,,,,,,,0001,,,,,,,,,0000000000000001,,'
 
 [[runs]]
 expr = '= 1'
 output = '1'
-datatype = 'boolean'
-shape = '1 1'
+encoded = 'e3,01,01,02,01,01,01'
 
 [[runs]]
 expr = '= 3 3 $ i. 6'
 output = '''
 1 0 1
 0 1 0'''
-datatype = 'boolean'
-shape = '2 3'
+encoded = 'e3,01,06,02,02,03,0100010001'
 
 [[runs]]
 expr = '= 5 4 3 4 5'
@@ -526,8 +557,7 @@ output = '''
 1 0 0 0 1
 0 1 0 1 0
 0 0 1 0 0'''
-datatype = 'boolean'
-shape = '3 5'
+encoded = 'e3,01,0f,02,03,05,01000000010001,0100000001'
 
 [[runs]]
 expr = '= i. 3'
@@ -535,97 +565,81 @@ output = '''
 1 0 0
 0 1 0
 0 0 1'''
-datatype = 'boolean'
-shape = '3 3'
+encoded = 'e3,01,09,02,03,03,0100000001,01'
 
 [[runs]]
 expr = '>. 4.6 4 _4 _4.6'
 output = '5 4 _4 _4'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,05,04,fcffffffffffffff,fcffffffffffffff'
 
 [[runs]]
 expr = '>./7 8 5 9 2'
 output = '9'
-datatype = 'integer'
-shape = ''
+encoded = 'e3,04,01,,09'
 
 [[runs]]
 expr = '>: 2 3 5 7'
 output = '3 4 6 8'
-datatype = 'integer'
-shape = '4'
+encoded = 'e3,04,04,01,04,03,04,06,08'
 
 [[runs]]
 expr = '^~ 3'
 output = '27'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,0000000000003b4'
 
 [[runs]]
 expr = '_'
 output = '_'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000f07f'
 
 [[runs]]
 expr = '_2 _ 3 + 5'
 output = '3 _ 8'
-datatype = 'floating'
-shape = '3'
+encoded = 'e3,08,03,01,03,000000000000084,000000000000f07f,000000000000204'
 
 [[runs]]
 expr = '_3j_3.3'
 output = '_3j_3.3'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,00000000000008c,6666666666660ac'
 
 [[runs]]
 expr = '__'
 output = '__'
-datatype = 'floating'
-shape = ''
+encoded = 'e3,08,01,,000000000000f0ff'
 
 [[runs]]
 expr = '__*3j3'
 output = '__j__'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,000000000000f0ff,000000000000f0ff'
 
 [[runs]]
 expr = '__j__'
 output = '__j__'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,000000000000f0ff,000000000000f0ff'
 
 [[runs]]
 expr = '_j_'
 output = '_j_'
-datatype = 'complex'
-shape = ''
+encoded = 'e3,1,01,,000000000000f07f,000000000000f07f'
 
 [[runs]]
 expr = 'j. 0 1 2 3 4'
 output = '0 0j1 0j2 0j3 0j4'
-datatype = 'complex'
-shape = '5'
+encoded = 'e3,1,05,01,05,,,,000000000000f03f,,000000000000004,,000000000000084,,000000000000104'
 
 [[runs]]
 expr = 'j. i. 5'
 output = '0 0j1 0j2 0j3 0j4'
-datatype = 'complex'
-shape = '5'
+encoded = 'e3,1,05,01,05,,,,000000000000f03f,,000000000000004,,000000000000084,,000000000000104'
 
 [[runs]]
 expr = '~. (3 3 $ 1 2 3 1 2 3 4 5 6)'
 output = '''
 1 2 3
 4 5 6'''
-datatype = 'integer'
-shape = '2 3'
+encoded = 'e3,04,06,02,02,03,01,02,03,04,05,06'
 
 [[runs]]
 expr = '~. 2 3 4 3 2 5 4 1'
 output = '2 3 4 5 1'
-datatype = 'integer'
-shape = '5'
+encoded = 'e3,04,05,01,05,02,03,04,05,01'


### PR DESCRIPTION
This allows us to test boxes (FORESHADOWING), and gerunds, and the like. It's also 'faster' (as it runs J fewer times), at the expense a buttload of weird ass-code.

There's some more patches for this lying around but I think this is the bulk, and it's useful as it is (BOX TESTS!).