### PR TITLE
feat: support parsing nums-with-base (16bff)

### DIFF
--- a/src/ctx/locales.rs
+++ b/src/ctx/locales.rs
@@ -102,9 +102,11 @@ impl Locales {
 }
 
 pub fn parse_name(name: &str) -> Result<(&str, Option<&str>)> {
+    if !name.ends_with('_') {
+        return Ok((name, None));
+    }
     let parts = name.split('_').collect_vec();
     Ok(match parts.len() {
-        1 => (parts[0], None),
         3 if parts[2].is_empty() => (parts[0], Some(parts[1])),
         _ => return Err(JError::IllFormedName).with_context(|| anyhow!("{name:?}")),
     })

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -411,7 +411,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
             {
                 debug!("7 Is Global Name w");
                 ctx.eval_mut().locales.assign_global(n, w.clone())?;
-                Ok(vec![any])
+                Ok(vec![w, any])
             }
             (Noun(names), IsGlobal, w, any)
                 if matches!(w, Conjunction(_, _) | Adverb(_, _) | Verb(_, _) | Noun(_)) =>
@@ -462,8 +462,11 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
     }
     match new_stack.pop_front() {
         Some(val) if new_stack.is_empty() => Ok(EvalOutput::Regular(val)),
-        _ => Err(JError::SyntaxError)
-            .with_context(|| anyhow!("expected a single output value but found {new_stack:?}")),
+        Some(val) => Err(JError::SyntaxError).with_context(|| {
+            anyhow!("expected a single output value but found {val:#?} followed by {new_stack:#?}")
+        }),
+        None => Err(JError::SyntaxError)
+            .with_context(|| anyhow!("expected a single output value but found nothing")),
     }
 }
 

--- a/src/foreign/files.rs
+++ b/src/foreign/files.rs
@@ -20,18 +20,30 @@ pub fn f_read_file(y: &Word) -> Result<Word> {
     }
 }
 
+pub fn arg_to_string_list(y: &BoxArray) -> Result<Vec<String>> {
+    if y.shape().len() > 1 {
+        return Err(JError::NonceError).context("only list-y args'");
+    }
+
+    y.iter().map(|path| {
+        let JArray::CharArray(path) = path else { return Err(JError::NonceError).context("string required") };
+        if path.shape().len() > 1 {
+            return Err(JError::NonceError).context("single string required");
+        }
+
+        Ok(path.iter().collect::<String>())
+    }).collect()
+}
+
 pub fn arg_to_string(y: &BoxArray) -> Result<String> {
     if y.len() != 1 {
         return Err(JError::NonceError).context("only one arg please");
     }
 
-    let path = y.iter().next().expect("just checked");
-    let JArray::CharArray(path) = path else { return Err(JError::NonceError).context("string required") };
-    if path.shape().len() != 1 {
-        return Err(JError::NonceError).context("single string required");
-    }
-
-    Ok(path.iter().collect::<String>())
+    Ok(arg_to_string_list(y)?
+        .into_iter()
+        .next()
+        .expect("just checked"))
 }
 
 pub fn arg_to_fs_path(y: &Word) -> Result<PathBuf> {

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -53,6 +53,15 @@ _9: 5
 _: 5
 5 _: 5
 _ _: _
+16bff
+16b0e
+16b16
+16b0
+16b1
+16b12
+16b123
+16bffffffff
+3b012
 
 NB. literal promotions
 1 0.5 2j3

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -482,6 +482,10 @@ NB. jsoft bug, apparently nothing starts with an empty string: {{ '' 4!:1 [ 0 [ 
 {{ 'a' 4!:1 [ 0 [ abc =. 4 5 6 [ def =. 7 8 9 }} ''
 {{ 'ab' 4!:1 [ 0 [ abc =. 4 5 6 [ def =. 7 8 9 }} ''
 
+NB. name erase
+4!:55 <'a'
+4!:55 'a';'b'
+
 NB. platform information
 NB. platform dependent actual result
 $ 9!:12 ''

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -1315,6 +1315,16 @@ output = '1 1 1'
 encoded = 'e3,01,03,01,03,010101'
 
 [[runs]]
+expr = "4!:55 'a';'b'"
+output = '1 1'
+encoded = 'e3,01,02,01,02,0101'
+
+[[runs]]
+expr = "4!:55 <'a'"
+output = '1'
+encoded = 'e3,01,01,,01'
+
+[[runs]]
 expr = '5 (+`-@.0) 2'
 output = '7'
 encoded = 'e3,04,01,,07'

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -979,6 +979,46 @@ output = '0.2'
 encoded = 'e3,08,01,,9a9999999999c93f'
 
 [[runs]]
+expr = '16b0'
+output = '0'
+encoded = 'e3,04,01,,'
+
+[[runs]]
+expr = '16b0e'
+output = '14'
+encoded = 'e3,04,01,,0e'
+
+[[runs]]
+expr = '16b1'
+output = '1'
+encoded = 'e3,04,01,,01'
+
+[[runs]]
+expr = '16b12'
+output = '18'
+encoded = 'e3,04,01,,12'
+
+[[runs]]
+expr = '16b123'
+output = '291'
+encoded = 'e3,04,01,,2301'
+
+[[runs]]
+expr = '16b16'
+output = '22'
+encoded = 'e3,04,01,,16'
+
+[[runs]]
+expr = '16bff'
+output = '255'
+encoded = 'e3,04,01,,ff'
+
+[[runs]]
+expr = '16bffffffff'
+output = '4294967295'
+encoded = 'e3,04,01,,ffffffff'
+
+[[runs]]
 expr = '1: 5'
 output = '1'
 encoded = 'e3,01,01,,01'
@@ -1272,6 +1312,11 @@ encoded = 'e3,08,01,,000000000000224'
 expr = '3^3'
 output = '27'
 encoded = 'e3,08,01,,0000000000003b4'
+
+[[runs]]
+expr = '3b012'
+output = '5'
+encoded = 'e3,04,01,,05'
 
 [[runs]]
 expr = '3e1'


### PR DESCRIPTION
Remove all the regex pre-validation from the number code and go back to trusting the parser, seems to parse all the current tests, so why not, eh.