### PR TITLE
feat: de-catastrophe the foreigns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",

--- a/src/foreign/conversion.rs
+++ b/src/foreign/conversion.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 
 use crate::{JArray, JError, Num, Word};
 
-pub fn f_dump_hex(x: Option<&Word>, y: &Word) -> Result<Word> {
+pub fn f_dump_hex(x: Option<&JArray>, y: &JArray) -> Result<Word> {
     if cfg!(not(target_pointer_width = "64")) {
         return Err(JError::NonceError).context("only support 64-bit (laziness)");
     }
@@ -12,18 +12,12 @@ pub fn f_dump_hex(x: Option<&Word>, y: &Word) -> Result<Word> {
     }
 
     match x {
-        Some(Word::Noun(x)) => match x.single_math_num() {
+        Some(x) => match x.single_math_num() {
             Some(x) if x == Num::Int(3) || x == Num::Int(11) => (),
             _ => return Err(JError::NonceError).context("unsupported mode"),
         },
         None => (),
-        _ => return Err(JError::DomainError).context("invalid mode"),
     }
-
-    let y = match y {
-        Word::Noun(arr) => arr,
-        _ => return Err(JError::NounResultWasRequired).context("can only serialise data"),
-    };
 
     let mut result = Vec::with_capacity(8);
     result.push(0xe3); // 64-bit, reversed
@@ -51,9 +45,8 @@ pub fn f_dump_hex(x: Option<&Word>, y: &Word) -> Result<Word> {
     .map(Word::Noun)
 }
 
-pub fn f_int_bytes(x: Option<&Word>, y: &Word) -> Result<Word> {
-    let Some(Word::Noun(x)) = x else { return Err(JError::DomainError).context("invalid mode type"); };
-    let Word::Noun(y) = y else { return Err(JError::DomainError).context("invalid data"); };
+pub fn f_int_bytes(x: Option<&JArray>, y: &JArray) -> Result<Word> {
+    let Some(x) = x else { return Err(JError::DomainError).context("invalid mode type"); };
     match x.single_math_num() {
         Some(x) if x == Num::Int(2) => (),
         _ => return Err(JError::NonceError).context("unsupported mode"),

--- a/src/foreign/files.rs
+++ b/src/foreign/files.rs
@@ -9,8 +9,8 @@ use crate::arrays::BoxArray;
 use crate::{JArray, JError, Word};
 
 // 1!:1
-pub fn f_read_file(y: &Word) -> Result<Word> {
-    let path = arg_to_fs_path(y)?;
+pub fn f_read_file(y: &JArray) -> Result<Word> {
+    let path = noun_to_fs_path(y)?;
 
     match fs::read_to_string(&path) {
         Ok(s) => Ok(Word::Noun(JArray::from_string(s))),
@@ -46,8 +46,8 @@ pub fn arg_to_string(y: &BoxArray) -> Result<String> {
         .expect("just checked"))
 }
 
-pub fn arg_to_fs_path(y: &Word) -> Result<PathBuf> {
-    let Word::Noun(JArray::BoxArray(y)) = y else { return Err(JError::NonceError).context("only support <'filepath' loading"); };
+pub fn noun_to_fs_path(y: &JArray) -> Result<PathBuf> {
+    let JArray::BoxArray(y) = y else { return Err(JError::NonceError).context("only support <'filepath' loading"); };
     let path = arg_to_string(y)?;
     fs::canonicalize(&path).with_context(|| anyhow!("canonicalising {path}"))
 }

--- a/src/foreign/host.rs
+++ b/src/foreign/host.rs
@@ -1,9 +1,9 @@
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 
 use crate::{arr0d, JArray, JError, Word};
 
-pub fn f_shell_out(y: &Word) -> Result<Word> {
-    let Word::Noun(JArray::CharArray(y)) = y else { return Err(JError::NonceError).context("string required") };
+pub fn f_shell_out(y: &JArray) -> Result<Word> {
+    let JArray::CharArray(y) = y else { return Err(JError::NonceError).context("string required") };
     // TODO: new lines
     let y = y.iter().collect::<String>();
     let result = match y.as_str() {
@@ -14,9 +14,9 @@ pub fn f_shell_out(y: &Word) -> Result<Word> {
     Ok(Word::Noun(JArray::from_string(result)))
 }
 
-pub fn f_getenv(y: &Word) -> Result<Word> {
-    let Word::Noun(JArray::CharArray(y)) = y else { return Err(JError::NonceError).context("string required") };
-    // TODO: new lines
+pub fn f_getenv(y: &JArray) -> Result<Word> {
+    ensure!(y.shape().len() <= 1, "rank 0");
+    let JArray::CharArray(y) = y else { return Err(JError::NonceError).context("string required") };
     let y = y.iter().collect::<String>();
     use std::env::VarError;
     match std::env::var(y) {

--- a/src/foreign/locales.rs
+++ b/src/foreign/locales.rs
@@ -3,8 +3,8 @@ use anyhow::{Context, Result};
 use crate::foreign::files::arg_to_string;
 use crate::{Ctx, HasEmpty, JArray, JError, Word};
 
-pub fn f_locales_set(ctx: &mut Ctx, y: &Word) -> Result<Word> {
-    let Word::Noun(JArray::BoxArray(y)) = y else { return Err(JError::DomainError).context("boxed name please"); };
+pub fn f_locales_set(ctx: &mut Ctx, y: &JArray) -> Result<Word> {
+    let JArray::BoxArray(y) = y else { return Err(JError::DomainError).context("boxed name please"); };
     let y = arg_to_string(y)?;
     ctx.eval_mut().locales.current = y;
     Ok(Word::Noun(JArray::empty()))

--- a/src/foreign/mod.rs
+++ b/src/foreign/mod.rs
@@ -7,10 +7,11 @@ mod names;
 mod scripts;
 
 use anyhow::{anyhow, Context, Result};
-use log::warn;
+use std::sync::Arc;
 
-use crate::{Ctx, HasEmpty, JArray, JError, Word};
+use crate::{Ctx, JArray, JError, Rank, Word};
 
+use crate::verbs::{DyadOwned, DyadOwnedF, MonadOwned, MonadOwnedF, PartialImpl};
 use conversion::*;
 use files::*;
 use global_param::*;
@@ -20,42 +21,69 @@ use names::*;
 use scripts::*;
 
 /// https://www.jsoftware.com/help/dictionary/xmain.htm
-pub fn foreign(ctx: &mut Ctx, l: i64, r: i64, x: Option<&Word>, y: &Word) -> Result<Word> {
-    let unsupported = |name: &'static str| -> Result<Word> {
+pub fn foreign(l: i64, r: i64) -> Result<PartialImpl> {
+    let unsupported = |name: &'static str| -> Result<PartialImpl> {
         Err(JError::NonceError).with_context(|| anyhow!("unsupported {name} foreign: {l}!:{r}"))
     };
 
-    #[allow(unused)]
-    let stub = |name: &'static str| -> Result<Word> {
-        warn!("stubbed out foreign {l}!:{r}: {name}");
-        Ok(Word::Noun(JArray::empty()))
+    fn mi(f: MonadOwnedF) -> Option<MonadOwned> {
+        Some(MonadOwned {
+            f,
+            rank: Rank::infinite(),
+        })
+    }
+    fn m0(f: MonadOwnedF) -> Option<MonadOwned> {
+        Some(MonadOwned {
+            f,
+            rank: Rank::zero(),
+        })
+    }
+    fn di(f: DyadOwnedF) -> Option<DyadOwned> {
+        Some(DyadOwned {
+            f,
+            rank: Rank::infinite_infinite(),
+        })
+    }
+
+    fn leg(
+        f: impl Fn(&mut Ctx, Option<&JArray>, &JArray) -> Result<Word> + 'static + Clone,
+    ) -> (Option<MonadOwned>, Option<DyadOwned>) {
+        let j = f.clone();
+        (
+            mi(Arc::new(move |ctx, y| f(ctx, None, y))),
+            di(Arc::new(move |ctx, x, y| j(ctx, Some(x), y))),
+        )
+    }
+
+    let name = format!("{l}!:{r}");
+
+    let (monad, dyad) = match (l, r) {
+        (0, k) => (mi(Arc::new(move |ctx, y| f_load_script(ctx, k, y))), None),
+        (1, 1) => (m0(Arc::new(move |_, y| f_read_file(y))), None),
+        (1, _) => return unsupported("file"),
+        (2, 0) => (mi(Arc::new(|_, y| f_shell_out(y))), None),
+        (2, 5) => (m0(Arc::new(|_, y| f_getenv(y))), None),
+        (2, 6) => (mi(Arc::new(|_, _| f_getpid())), None),
+        (2, _) => return unsupported("host"),
+        (3, 3) => leg(|_ctx, x, y| f_dump_hex(x, y)),
+        (3, 4) => leg(|_ctx, x, y| f_int_bytes(x, y)),
+        (3, _) => return unsupported("conversion"),
+        (4, 0) => (m0(Arc::new(|ctx, y| f_name_status(ctx, y))), None),
+        (4, 1) => leg(|ctx, x, y| f_name_namelist(ctx, x, y)),
+        (4, 55) => (m0(Arc::new(|ctx, y| f_name_erase(ctx, y))), None),
+        (5, _) => return unsupported("representation"),
+        (6, _) => return unsupported("time"),
+        (7, _) => return unsupported("space"),
+        (8, _) => return unsupported("format"),
+        (9, 12) => (mi(Arc::new(|_, _| f_os_type())), None),
+        (9, _) => return unsupported("global param"),
+        (13, _) => return unsupported("debug"),
+        (15, _) => return unsupported("dll"),
+        (18, 4) => (mi(Arc::new(|ctx, y| f_locales_set(ctx, y))), None),
+        (18, _) => return unsupported("locales"),
+        (128, _) => return unsupported("misc"),
+        _ => return unsupported("major"),
     };
 
-    match (l, r) {
-        (0, k) => f_load_script(ctx, k, y),
-        (1, 1) => f_read_file(y).context("reading file"),
-        (1, _) => unsupported("file"),
-        (2, 0) => f_shell_out(y),
-        (2, 5) => f_getenv(y),
-        (2, 6) => f_getpid(),
-        (2, _) => unsupported("host"),
-        (3, 3) => f_dump_hex(x, y),
-        (3, 4) => f_int_bytes(x, y),
-        (3, _) => unsupported("conversion"),
-        (4, 0) => f_name_status(ctx, y),
-        (4, 1) => f_name_namelist(ctx, x, y),
-        (4, 55) => f_name_erase(ctx, y),
-        (5, _) => unsupported("representation"),
-        (6, _) => unsupported("time"),
-        (7, _) => unsupported("space"),
-        (8, _) => unsupported("format"),
-        (9, 12) => f_os_type(),
-        (9, _) => unsupported("global param"),
-        (13, _) => unsupported("debug"),
-        (15, _) => unsupported("dll"),
-        (18, 4) => f_locales_set(ctx, y),
-        (18, _) => unsupported("locales"),
-        (128, _) => unsupported("misc"),
-        _ => unsupported("major"),
-    }
+    Ok(PartialImpl { name, monad, dyad })
 }

--- a/src/foreign/names.rs
+++ b/src/foreign/names.rs
@@ -8,8 +8,8 @@ use crate::foreign::files::{arg_to_string, arg_to_string_list};
 use crate::{arr0d, Ctx, JArray, JError, Word};
 
 // 4!:0
-pub fn f_name_status(ctx: &Ctx, y: &Word) -> Result<Word> {
-    let Word::Noun(JArray::BoxArray(y)) = y else { return Err(JError::DomainError).context("boxed name please"); };
+pub fn f_name_status(ctx: &Ctx, y: &JArray) -> Result<Word> {
+    let JArray::BoxArray(y) = y else { return Err(JError::DomainError).context("boxed name please"); };
     let name = arg_to_string(y)?;
     let result = match ctx.eval().locales.lookup(&name) {
         Ok(Some(w)) => name_code(w)
@@ -23,18 +23,14 @@ pub fn f_name_status(ctx: &Ctx, y: &Word) -> Result<Word> {
 }
 
 // 4!:1
-pub fn f_name_namelist(ctx: &Ctx, x: Option<&Word>, y: &Word) -> Result<Word> {
-    let Word::Noun(y) = y else { return Err(JError::DomainError).context("non-noun y"); };
+pub fn f_name_namelist(ctx: &Ctx, x: Option<&JArray>, y: &JArray) -> Result<Word> {
     let y = y.approx_i64_list().context("name list's y")?;
     let x = match x {
-        Some(x) => {
-            let Word::Noun(x) = x else { return Err(JError::DomainError).context("non-noun x"); };
-            Some(
-                x.when_string()
-                    .ok_or(JError::DomainError)
-                    .context("single string for x")?,
-            )
-        }
+        Some(x) => Some(
+            x.when_string()
+                .ok_or(JError::DomainError)
+                .context("single string for x")?,
+        ),
         None => None,
     };
 
@@ -81,8 +77,8 @@ pub fn f_name_namelist(ctx: &Ctx, x: Option<&Word>, y: &Word) -> Result<Word> {
 }
 
 // 4!:55
-pub fn f_name_erase(ctx: &mut Ctx, y: &Word) -> Result<Word> {
-    let Word::Noun(JArray::BoxArray(y)) = y else { return Err(JError::DomainError).context("boxed name please"); };
+pub fn f_name_erase(ctx: &mut Ctx, y: &JArray) -> Result<Word> {
+    let JArray::BoxArray(y) = y else { return Err(JError::DomainError).context("boxed name please"); };
     let mut ret = Vec::new();
     for name in arg_to_string_list(y)? {
         ret.push(ctx.eval_mut().locales.erase(&name).is_ok() as u8);

--- a/src/foreign/scripts.rs
+++ b/src/foreign/scripts.rs
@@ -6,10 +6,10 @@ use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 use log::info;
 
-use super::files::arg_to_fs_path;
+use crate::foreign::files::noun_to_fs_path;
 use crate::{feed, Ctx, EvalOutput, HasEmpty, JArray, JError, Word};
 
-pub fn f_load_script(ctx: &mut Ctx, k: i64, y: &Word) -> Result<Word> {
+pub fn f_load_script(ctx: &mut Ctx, k: i64, y: &JArray) -> Result<Word> {
     let [src, err, display]: [char; 3] = format!("{k:03}")
         .chars()
         .collect_vec()
@@ -36,7 +36,7 @@ pub fn f_load_script(ctx: &mut Ctx, k: i64, y: &Word) -> Result<Word> {
         _ => return Err(JError::NonceError).context("unrecognised 'err' option"),
     }
 
-    let path = arg_to_fs_path(y)?;
+    let path = noun_to_fs_path(y)?;
 
     let mut last = EvalOutput::Regular(Word::Nothing);
     for (off, line) in fs::read_to_string(&path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 mod arrays;
 mod cells;
 mod ctx;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,10 @@ fn primitive_conjunctions(sentence: &str) -> Option<ModifierImpl> {
         "::" => conj("::", c_assign_adverse),
         ";." => conj(";.", c_cut),
         "!." => conj("!.", c_not_implemented),
-        "!:" => conj("!:", c_foreign),
+        "!:" => ModifierImpl::FormingConjunction(FormingConjunction {
+            name: "!:",
+            f: c_foreign,
+        }),
         "[." => conj("[.", c_not_implemented),
         "]." => conj("].", c_not_implemented),
         "\"" => conj("\"", c_quote),

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -16,6 +16,7 @@ pub use conj::*;
 pub enum ModifierImpl {
     Adverb(SimpleAdverb),
     Conjunction(SimpleConjunction),
+    FormingConjunction(FormingConjunction),
     DerivedAdverb { l: Box<Word>, r: Box<Word> },
 }
 
@@ -43,7 +44,15 @@ impl ModifierImpl {
                     "TODO: DerivedAdverb l: {l:?} r: {r:?} x: {x:?} u: {u:?} v: {v:?} y: {y:?}"
                 ),
             },
+            ModifierImpl::FormingConjunction(_) => bail!("shouldn't be calling these"),
         }
+    }
+
+    pub fn form(&self, ctx: &mut Ctx, u: &Word, v: &Word) -> Result<Option<Word>> {
+        Ok(Some(match self {
+            ModifierImpl::FormingConjunction(c) => (c.f)(ctx, u, v)?,
+            _ => return Ok(None),
+        }))
     }
 
     pub fn farcical(&self, m: &JArray, n: &JArray) -> Result<bool> {

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::ops::Deref;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -6,34 +5,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use super::ranks::Rank;
 use crate::cells::{apply_cells, fill_promote_reshape, generate_cells, monad_apply, monad_cells};
 use crate::eval::eval_lines;
+use crate::verbs::partial::PartialImpl;
+use crate::verbs::primitive::PrimitiveImpl;
+use crate::verbs::DyadRank;
 use crate::{primitive_verbs, Ctx, JArray, JError, Num, Word};
-
-#[derive(Copy, Clone)]
-pub struct Monad {
-    // TODO: NOT public
-    pub f: fn(&JArray) -> Result<JArray>,
-    pub rank: Rank,
-}
-
-pub type DyadF = fn(&JArray, &JArray) -> Result<JArray>;
-pub type DyadRank = (Rank, Rank);
-
-#[derive(Copy, Clone)]
-pub struct Dyad {
-    pub f: DyadF,
-    pub rank: DyadRank,
-}
-
-#[derive(Copy, Clone)]
-pub struct PrimitiveImpl {
-    // TODO: NOT public
-    pub name: &'static str,
-    // TODO: NOT public
-    pub monad: Monad,
-    // TODO: NOT public
-    pub dyad: Option<Dyad>,
-    pub inverse: Option<&'static str>,
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum VerbImpl {
@@ -41,6 +16,8 @@ pub enum VerbImpl {
 
     // dyadic
     Anonymous(bool, Vec<Word>),
+
+    Partial(PartialImpl),
 
     //Adverb or Conjunction modified Verb eg. +/ or u^:n etc.
     //Modifiers take a left and right argument refered to as either
@@ -142,6 +119,31 @@ impl VerbImpl {
                 }
                 other => Err(JError::DomainError)
                     .with_context(|| anyhow!("primitive on non-nouns: {other:#?}")),
+            },
+            VerbImpl::Partial(imp) => match (x, y) {
+                (None, Noun(y)) => {
+                    let monad = imp
+                        .monad
+                        .as_ref()
+                        .ok_or(JError::DomainError)
+                        .with_context(|| anyhow!("there is no monadic partial {:?}", imp.name))?;
+                    exec_monad_inner(monad.f.as_ref(), monad.rank, y)
+                        .with_context(|| anyhow!("y: {y:?}"))
+                        .with_context(|| anyhow!("monadic partial {:?}", imp.name))
+                }
+                (Some(Noun(x)), Noun(y)) => {
+                    let dyad = imp
+                        .dyad
+                        .as_ref()
+                        .ok_or(JError::DomainError)
+                        .with_context(|| anyhow!("there is no dyadic partial {:?}", imp.name))?;
+                    exec_dyad_inner(dyad.f.as_ref(), dyad.rank, x, y)
+                        .with_context(|| anyhow!("x: {x:?}"))
+                        .with_context(|| anyhow!("y: {y:?}"))
+                        .with_context(|| anyhow!("dyadic partial {:?}", imp.name))
+                }
+                other => Err(JError::DomainError)
+                    .with_context(|| anyhow!("partial on non-nouns: {other:#?}")),
             },
             VerbImpl::Anonymous(dyadic, words) => {
                 let mut ctx = ctx.nest();
@@ -246,52 +248,5 @@ fn must_be_box(v: Word) -> Result<VerbResult> {
         Word::Noun(arr) => Ok((Vec::new(), vec![arr])),
         _ => Err(JError::DomainError)
             .with_context(|| anyhow!("unexpected non-noun in noun context: {v:?}")),
-    }
-}
-
-impl PrimitiveImpl {
-    pub fn monad(name: &'static str, f: fn(&JArray) -> Result<JArray>) -> Self {
-        Self {
-            name,
-            monad: Monad {
-                f,
-                rank: Rank::infinite(),
-            },
-            dyad: None,
-            inverse: None,
-        }
-    }
-
-    pub const fn new(
-        name: &'static str,
-        monad: fn(&JArray) -> Result<JArray>,
-        dyad: fn(&JArray, &JArray) -> Result<JArray>,
-        ranks: (Rank, Rank, Rank),
-        inverse: Option<&'static str>,
-    ) -> Self {
-        Self {
-            name,
-            monad: Monad {
-                f: monad,
-                rank: ranks.0,
-            },
-            dyad: Some(Dyad {
-                f: dyad,
-                rank: (ranks.1, ranks.2),
-            }),
-            inverse,
-        }
-    }
-}
-
-impl fmt::Debug for PrimitiveImpl {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "PrimitiveImpl({})", self.name)
-    }
-}
-
-impl PartialEq for PrimitiveImpl {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
     }
 }

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -2,6 +2,8 @@ mod impl_impl;
 mod impl_maths;
 mod impl_shape;
 mod maff;
+mod partial;
+mod primitive;
 mod ranks;
 
 use std::collections::VecDeque;
@@ -20,13 +22,16 @@ use try_partialord::TrySort;
 use JArray::*;
 
 use maff::*;
-pub use ranks::Rank;
+pub use ranks::{DyadRank, Rank};
 
 use crate::arrays::{IntoVec, JArrayCow};
 use crate::cells::fill_promote_list_cow;
 pub use impl_impl::*;
 pub use impl_maths::*;
 pub use impl_shape::*;
+
+pub use partial::*;
+pub use primitive::*;
 
 pub fn v_not_implemented_monad(_y: &JArray) -> Result<JArray> {
     Err(JError::NonceError.into())

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -3,19 +3,19 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use crate::JArray;
+use crate::{Ctx, JArray, Word};
 
 use super::ranks::{DyadRank, Rank};
 
 #[derive(Clone)]
 pub struct MonadOwned {
-    pub f: Arc<dyn Fn(&JArray) -> Result<JArray>>,
+    pub f: Arc<dyn Fn(&mut Ctx, &JArray) -> Result<Word>>,
     pub rank: Rank,
 }
 
 #[derive(Clone)]
 pub struct DyadOwned {
-    pub f: Arc<dyn Fn(&JArray, &JArray) -> Result<JArray>>,
+    pub f: Arc<dyn Fn(&mut Ctx, &JArray, &JArray) -> Result<Word>>,
     pub rank: DyadRank,
 }
 

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::JArray;
+
+use super::ranks::{DyadRank, Rank};
+
+#[derive(Clone)]
+pub struct MonadOwned {
+    pub f: Arc<dyn Fn(&JArray) -> Result<JArray>>,
+    pub rank: Rank,
+}
+
+#[derive(Clone)]
+pub struct DyadOwned {
+    pub f: Arc<dyn Fn(&JArray, &JArray) -> Result<JArray>>,
+    pub rank: DyadRank,
+}
+
+#[derive(Clone)]
+pub struct PartialImpl {
+    pub name: String,
+    pub monad: Option<MonadOwned>,
+    pub dyad: Option<DyadOwned>,
+}
+
+impl fmt::Debug for PartialImpl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PartialImpl({})", self.name)
+    }
+}
+
+impl PartialEq for PartialImpl {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -7,15 +7,19 @@ use crate::{Ctx, JArray, Word};
 
 use super::ranks::{DyadRank, Rank};
 
+pub type MonadOwnedF = Arc<dyn Fn(&mut Ctx, &JArray) -> Result<Word>>;
+
 #[derive(Clone)]
 pub struct MonadOwned {
-    pub f: Arc<dyn Fn(&mut Ctx, &JArray) -> Result<Word>>,
+    pub f: MonadOwnedF,
     pub rank: Rank,
 }
 
+pub type DyadOwnedF = Arc<dyn Fn(&mut Ctx, &JArray, &JArray) -> Result<Word>>;
+
 #[derive(Clone)]
 pub struct DyadOwned {
-    pub f: Arc<dyn Fn(&mut Ctx, &JArray, &JArray) -> Result<Word>>,
+    pub f: DyadOwnedF,
     pub rank: DyadRank,
 }
 

--- a/src/verbs/primitive.rs
+++ b/src/verbs/primitive.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+use anyhow::Result;
+
+use crate::JArray;
+
+use super::ranks::{DyadRank, Rank};
+
+#[derive(Copy, Clone)]
+pub struct Monad {
+    pub f: fn(&JArray) -> Result<JArray>,
+    pub rank: Rank,
+}
+
+#[derive(Copy, Clone)]
+pub struct Dyad {
+    pub f: fn(&JArray, &JArray) -> Result<JArray>,
+    pub rank: DyadRank,
+}
+
+#[derive(Copy, Clone)]
+pub struct PrimitiveImpl {
+    pub name: &'static str,
+    pub monad: Monad,
+    pub dyad: Option<Dyad>,
+    pub inverse: Option<&'static str>,
+}
+
+impl PrimitiveImpl {
+    pub fn monad(name: &'static str, f: fn(&JArray) -> Result<JArray>) -> Self {
+        Self {
+            name,
+            monad: Monad {
+                f,
+                rank: Rank::infinite(),
+            },
+            dyad: None,
+            inverse: None,
+        }
+    }
+
+    pub const fn new(
+        name: &'static str,
+        monad: fn(&JArray) -> Result<JArray>,
+        dyad: fn(&JArray, &JArray) -> Result<JArray>,
+        ranks: (Rank, Rank, Rank),
+        inverse: Option<&'static str>,
+    ) -> Self {
+        Self {
+            name,
+            monad: Monad {
+                f: monad,
+                rank: ranks.0,
+            },
+            dyad: Some(Dyad {
+                f: dyad,
+                rank: (ranks.1, ranks.2),
+            }),
+            inverse,
+        }
+    }
+}
+
+impl fmt::Debug for PrimitiveImpl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PrimitiveImpl({})", self.name)
+    }
+}
+
+impl PartialEq for PrimitiveImpl {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}

--- a/src/verbs/ranks.rs
+++ b/src/verbs/ranks.rs
@@ -4,6 +4,7 @@ use crate::JError;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Rank(u8);
+pub type DyadRank = (Rank, Rank);
 
 impl Rank {
     pub fn new(val: u32) -> Result<Self> {


### PR DESCRIPTION
Add a new `Partial` verb type, next to `Primitive` and `Anonymous`.

These verbs are the result of adverb and conjunction ... construction? Formation?

An adverb/conjunction forms into a verb, then that verb can be manipulated and executed. Logic can execute while this formation happens; this is not just a parser hack. (It's currently implemented in the parser, as a hack, but it won't be when everything has migrated).

This enables:

Partial execution of a foreign knows what it's doing:

```
   18!:4
18!:4
```

```
   19!:4
error: feature not supported yet
cause: unsupported major foreign: 19!:4
cause: evaluating "19!:4"
```

On main, this is not pre-validated:
```
   19!:4
m !: n
```

And, foreigns can have ranks and lack monads or dyads like normal verbs:

```
   2 (2!:5) 3
error: Kitchen sink error, you probably did something wrong
cause: there is no dyadic partial "2!:5"
cause: evaluating 2 dyad
cause: evaluating "2 (2!:5) 3"
```

(`1!:1` is rank 0)
```
   (1!:1) 'Cargo.toml';'Cargo.lock'
[[[, p, a, c, k, ...,  ,  ,  ,  ,  ],
 [#,  , T, h, i, ..., 0, a, 3, ", 
]]
```

Now we just need to move every other conjunction and adverb over.

We should probably decide whether functions take `(&mut Ctx, &Word, &Word) -> Word` or `(&mut Ctx, JArray, JArray) -> JArrayCow` or something first.