### PR TITLE
feat: forming adverbs

### DIFF
--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -182,43 +182,22 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 ])
             }
             // (V|N) A anything - 3 Adverb
-            (ref w, u @ Verb(_, _), Adverb(sa, a), any)
+            (ref w, u @ Verb(_, _), Adverb(_, a), any)
                 if matches!(
                     w,
                     StartOfLine | IsGlobal | IsLocal | LP | Adverb(_, _) | Verb(_, _) | Noun(_)
                 ) =>
             {
                 debug!("3 adverb V A _");
-                if let Some(formed) = a.form_adverb(ctx, &u)? {
-                    Ok(vec![fragment.0, formed, any])
-                } else {
-                    let Verb(sv, v) = u else { unreachable!("matched") };
-                    let verb_str = format!("{}{}", sv, sa);
-                    let dv = VerbImpl::DerivedVerb {
-                        l: Box::new(Verb(sv, v.clone())),
-                        m: Box::new(Adverb(sa, a)),
-                    };
-                    Ok(vec![fragment.0, Verb(verb_str, dv), any])
-                }
+                Ok(vec![fragment.0, a.form_adverb(ctx, &u)?, any])
             }
-            (ref w, n @ Noun(_), Adverb(sa, a), any)
+            (ref w, n @ Noun(_), Adverb(_, a), any)
                 if matches!(
                     w,
                     StartOfLine | IsGlobal | IsLocal | LP | Adverb(_, _) | Verb(_, _) | Noun(_)
                 ) =>
             {
-                if let Some(formed) = a.form_adverb(ctx, &n)? {
-                    Ok(vec![fragment.0, formed, any])
-                } else {
-                    let Noun(n) = n else { unreachable!("matched") };
-                    debug!("3 adverb N A _");
-                    let verb_str = format!("m{}", sa);
-                    let dv = VerbImpl::DerivedVerb {
-                        l: Box::new(Noun(n)),
-                        m: Box::new(Adverb(sa, a)),
-                    };
-                    Ok(vec![fragment.0, Verb(verb_str, dv), any])
-                }
+                Ok(vec![fragment.0, a.form_adverb(ctx, &n)?, any])
             }
             //// (V|N) C (V|N) - 4 Conjunction
             (ref w, l, Conjunction(_sc, c), r)

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -150,7 +150,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 debug!("0 monad");
                 Ok(vec![
                     fragment.0,
-                    v.exec(ctx, None, &Noun(y)).map(Word::Noun)?,
+                    v.exec(ctx, None, &y).map(Word::Noun)?,
                     any,
                 ])
             }
@@ -164,7 +164,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 Ok(vec![
                     fragment.0,
                     Verb(us, u.clone()),
-                    v.exec(ctx, None, &Noun(y)).map(Word::Noun)?,
+                    v.exec(ctx, None, &y).map(Word::Noun)?,
                 ])
             }
             (ref w, Noun(x), Verb(_, ref v), Noun(y))
@@ -176,7 +176,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 debug!("2 dyad");
                 Ok(vec![
                     fragment.0,
-                    v.exec(ctx, Some(&Noun(x)), &Noun(y))
+                    v.exec(ctx, Some(&x), &y)
                         .context("evaluating 2 dyad")
                         .map(Word::Noun)?,
                 ])

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -182,35 +182,45 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 ])
             }
             // (V|N) A anything - 3 Adverb
-            (ref w, Verb(sv, ref v), Adverb(sa, a), any)
+            (ref w, u @ Verb(_, _), Adverb(sa, a), any)
                 if matches!(
                     w,
                     StartOfLine | IsGlobal | IsLocal | LP | Adverb(_, _) | Verb(_, _) | Noun(_)
                 ) =>
             {
                 debug!("3 adverb V A _");
-                let verb_str = format!("{}{}", sv, sa);
-                let dv = VerbImpl::DerivedVerb {
-                    l: Box::new(Verb(sv, v.clone())),
-                    r: Box::new(Nothing),
-                    m: Box::new(Adverb(sa, a)),
-                };
-                Ok(vec![fragment.0, Verb(verb_str, dv), any])
+                if let Some(formed) = a.form_adverb(ctx, &u)? {
+                    Ok(vec![fragment.0, formed, any])
+                } else {
+                    let Verb(sv, v) = u else { unreachable!("matched") };
+                    let verb_str = format!("{}{}", sv, sa);
+                    let dv = VerbImpl::DerivedVerb {
+                        l: Box::new(Verb(sv, v.clone())),
+                        r: Box::new(Nothing),
+                        m: Box::new(Adverb(sa, a)),
+                    };
+                    Ok(vec![fragment.0, Verb(verb_str, dv), any])
+                }
             }
-            (ref w, Noun(n), Adverb(sa, a), any)
+            (ref w, n @ Noun(_), Adverb(sa, a), any)
                 if matches!(
                     w,
                     StartOfLine | IsGlobal | IsLocal | LP | Adverb(_, _) | Verb(_, _) | Noun(_)
                 ) =>
             {
-                debug!("3 adverb N A _");
-                let verb_str = format!("m{}", sa);
-                let dv = VerbImpl::DerivedVerb {
-                    l: Box::new(Noun(n)),
-                    r: Box::new(Nothing),
-                    m: Box::new(Adverb(sa, a)),
-                };
-                Ok(vec![fragment.0, Verb(verb_str, dv), any])
+                if let Some(formed) = a.form_adverb(ctx, &n)? {
+                    Ok(vec![fragment.0, formed, any])
+                } else {
+                    let Noun(n) = n else { unreachable!("matched") };
+                    debug!("3 adverb N A _");
+                    let verb_str = format!("m{}", sa);
+                    let dv = VerbImpl::DerivedVerb {
+                        l: Box::new(Noun(n)),
+                        r: Box::new(Nothing),
+                        m: Box::new(Adverb(sa, a)),
+                    };
+                    Ok(vec![fragment.0, Verb(verb_str, dv), any])
+                }
             }
             //// (V|N) C (V|N) - 4 Conjunction
             (ref w, l, Conjunction(_sc, c), r)

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -196,7 +196,6 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                     let verb_str = format!("{}{}", sv, sa);
                     let dv = VerbImpl::DerivedVerb {
                         l: Box::new(Verb(sv, v.clone())),
-                        r: Box::new(Nothing),
                         m: Box::new(Adverb(sa, a)),
                     };
                     Ok(vec![fragment.0, Verb(verb_str, dv), any])
@@ -216,7 +215,6 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                     let verb_str = format!("m{}", sa);
                     let dv = VerbImpl::DerivedVerb {
                         l: Box::new(Noun(n)),
-                        r: Box::new(Nothing),
                         m: Box::new(Adverb(sa, a)),
                     };
                     Ok(vec![fragment.0, Verb(verb_str, dv), any])
@@ -233,7 +231,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                     && !(matches!(l, Noun(_)) && matches!(r, Noun(_))) =>
             {
                 debug!("4 Conj");
-                let (farcical, formed) = c.form(ctx, &l, &r)?;
+                let (farcical, formed) = c.form_conjunction(ctx, &l, &r)?;
                 assert!(!farcical);
                 Ok(vec![fragment.0, formed])
             }
@@ -245,7 +243,7 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
             {
                 debug!("4 Conj N C N");
                 let (farcical, formed) =
-                    c.form(ctx, &Word::Noun(m.clone()), &Word::Noun(n.clone()))?;
+                    c.form_conjunction(ctx, &Word::Noun(m.clone()), &Word::Noun(n.clone()))?;
                 if !farcical {
                     Ok(vec![fragment.0, formed])
                 } else {
@@ -300,16 +298,17 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
             // (C|A|V|N) (C|A|V|N) anything - 6 Hook/Adverb
             // Only the combinations A A, C N, C V, N C, V C, and V V are valid;
             // the rest result in syntax errors.
-            (ref w, Adverb(sa0, a0), Adverb(sa1, a1), any)
+            (ref w, Adverb(sa0, _), Adverb(sa1, _), _any)
                 if matches!(w, StartOfLine | IsGlobal | IsLocal | LP) =>
             {
                 debug!("6 Hook/Adverb A A _");
-                let adverb_str = format!("{} {}", sa0, sa1);
-                let da = ModifierImpl::DerivedAdverb {
-                    l: Box::new(Adverb(sa0, a0.clone())),
-                    r: Box::new(Adverb(sa1, a1.clone())),
-                };
-                Ok(vec![fragment.0, Adverb(adverb_str, da), any])
+                bail!("unable to bond adverbs: {sa0:?} {sa1:?}")
+                // let adverb_str = format!("{} {}", sa0, sa1);
+                // let da = ModifierImpl::DerivedAdverb {
+                //     l: Box::new(Adverb(sa0, a0.clone())),
+                //     r: Box::new(Adverb(sa1, a1.clone())),
+                // };
+                // Ok(vec![fragment.0, Adverb(adverb_str, da), any])
             }
             (ref w, Conjunction(sc, c), Noun(n), any)
                 if matches!(w, StartOfLine | IsGlobal | IsLocal | LP) =>
@@ -317,8 +316,8 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 debug!("6 Hook/Adverb C N _");
                 let adverb_str = format!("{} n", sc);
                 let da = ModifierImpl::DerivedAdverb {
-                    l: Box::new(Conjunction(sc, c.clone())),
-                    r: Box::new(Noun(n)),
+                    c: Box::new(c),
+                    u: Box::new(Noun(n)),
                 };
                 Ok(vec![fragment.0, Adverb(adverb_str, da), any])
             }
@@ -328,8 +327,8 @@ pub fn eval_suspendable(sentence: Vec<Word>, ctx: &mut Ctx) -> Result<EvalOutput
                 debug!("6 Hook/Adverb C V _");
                 let adverb_str = format!("{} {}", sc, sv);
                 let da = ModifierImpl::DerivedAdverb {
-                    l: Box::new(Conjunction(sc, c.clone())),
-                    r: Box::new(Verb(sv, v.clone())),
+                    c: Box::new(c),
+                    u: Box::new(Verb(sv, v.clone())),
                 };
                 Ok(vec![fragment.0, Adverb(adverb_str, da), any])
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,15 +174,15 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     let adverb = |name, f| ModifierImpl::Adverb2(SimpleAdverb2 { name, f });
     Some(match sentence {
         "~" => adverb("~", a_tilde),
-        "/" => legacy("/", a_slash),
+        "/" => adverb("/", a_slash),
         "/." => legacy("/.", a_slash_dot),
         "\\" => legacy("\\", a_backslash),
         "\\." => legacy("\\.", a_suffix_outfix),
-        "]:" => legacy("]:", a_not_implemented),
+        "]:" => adverb("]:", a_not_implemented),
         "}" => legacy("}", a_curlyrt),
-        "b." => legacy("b.", a_not_implemented),
-        "f." => legacy("f.", a_not_implemented),
-        "M." => legacy("M.", a_not_implemented),
+        "b." => adverb("b.", a_not_implemented),
+        "f." => adverb("f.", a_not_implemented),
+        "M." => adverb("M.", a_not_implemented),
         _ => return None,
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,7 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
 
 fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     use modifiers::*;
-    let legacy = |name, f| ModifierImpl::Adverb(SimpleAdverb { name, f });
-    let adverb = |name, f| ModifierImpl::Adverb2(SimpleAdverb2 { name, f });
+    let adverb = |name, f| ModifierImpl::Adverb(SimpleAdverb { name, f });
     Some(match sentence {
         "~" => adverb("~", a_tilde),
         "/" => adverb("/", a_slash),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
         "\\" => adverb("\\", a_backslash),
         "\\." => adverb("\\.", a_suffix_outfix),
         "]:" => adverb("]:", a_not_implemented),
-        "}" => legacy("}", a_curlyrt),
+        "}" => adverb("}", a_curlyrt),
         "b." => adverb("b.", a_not_implemented),
         "f." => adverb("f.", a_not_implemented),
         "M." => adverb("M.", a_not_implemented),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     Some(match sentence {
         "~" => adverb("~", a_tilde),
         "/" => adverb("/", a_slash),
-        "/." => legacy("/.", a_slash_dot),
+        "/." => adverb("/.", a_slash_dot),
         "\\" => legacy("\\", a_backslash),
         "\\." => legacy("\\.", a_suffix_outfix),
         "]:" => adverb("]:", a_not_implemented),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,18 +170,19 @@ fn primitive_verbs(sentence: &str) -> Option<VerbImpl> {
 
 fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
     use modifiers::*;
-    let adverb = |name, f| ModifierImpl::Adverb(SimpleAdverb { name, f });
+    let legacy = |name, f| ModifierImpl::Adverb(SimpleAdverb { name, f });
+    let adverb = |name, f| ModifierImpl::Adverb2(SimpleAdverb2 { name, f });
     Some(match sentence {
         "~" => adverb("~", a_tilde),
-        "/" => adverb("/", a_slash),
-        "/." => adverb("/.", a_slash_dot),
-        "\\" => adverb("\\", a_backslash),
-        "\\." => adverb("\\.", a_suffix_outfix),
-        "]:" => adverb("]:", a_not_implemented),
-        "}" => adverb("}", a_curlyrt),
-        "b." => adverb("b.", a_not_implemented),
-        "f." => adverb("f.", a_not_implemented),
-        "M." => adverb("M.", a_not_implemented),
+        "/" => legacy("/", a_slash),
+        "/." => legacy("/.", a_slash_dot),
+        "\\" => legacy("\\", a_backslash),
+        "\\." => legacy("\\.", a_suffix_outfix),
+        "]:" => legacy("]:", a_not_implemented),
+        "}" => legacy("}", a_curlyrt),
+        "b." => legacy("b.", a_not_implemented),
+        "f." => legacy("f.", a_not_implemented),
+        "M." => legacy("M.", a_not_implemented),
         _ => return None,
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
         "~" => adverb("~", a_tilde),
         "/" => adverb("/", a_slash),
         "/." => adverb("/.", a_slash_dot),
-        "\\" => legacy("\\", a_backslash),
+        "\\" => adverb("\\", a_backslash),
         "\\." => legacy("\\.", a_suffix_outfix),
         "]:" => adverb("]:", a_not_implemented),
         "}" => legacy("}", a_curlyrt),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ fn primitive_adverbs(sentence: &str) -> Option<ModifierImpl> {
         "/" => adverb("/", a_slash),
         "/." => adverb("/.", a_slash_dot),
         "\\" => adverb("\\", a_backslash),
-        "\\." => legacy("\\.", a_suffix_outfix),
+        "\\." => adverb("\\.", a_suffix_outfix),
         "]:" => adverb("]:", a_not_implemented),
         "}" => legacy("}", a_curlyrt),
         "b." => adverb("b.", a_not_implemented),

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -11,8 +11,7 @@ use crate::number::promote_to_array;
 use crate::verbs::{v_self_classify, DyadOwned, MonadOwned, PartialImpl, VerbImpl};
 use crate::{primitive_verbs, Ctx, JArray, JError, Rank, Word};
 
-pub type AdverbFn = fn(&mut Ctx, Option<&Word>, &Word, &Word) -> Result<Word>;
-pub type AdverbFn2 = fn(&mut Ctx, &Word) -> Result<Word>;
+pub type AdverbFn = fn(&mut Ctx, &Word) -> Result<Word>;
 
 #[derive(Clone)]
 pub struct SimpleAdverb {
@@ -27,24 +26,6 @@ impl PartialEq for SimpleAdverb {
 }
 
 impl fmt::Debug for SimpleAdverb {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SimpleAdverb({:?})", self.name)
-    }
-}
-
-#[derive(Clone)]
-pub struct SimpleAdverb2 {
-    pub name: &'static str,
-    pub f: AdverbFn2,
-}
-
-impl PartialEq for SimpleAdverb2 {
-    fn eq(&self, other: &Self) -> bool {
-        self.name.eq(other.name)
-    }
-}
-
-impl fmt::Debug for SimpleAdverb2 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SimpleAdverb2({:?})", self.name)
     }
@@ -241,10 +222,8 @@ pub fn a_curlyrt(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
         return Err(JError::NonceError).context("u must be a list");
     }
     let u = u.approx_usize_list()?;
-    let (monad, dyad) = PartialImpl::from_legacy_inf(move |ctx, x, y| match x {
-        Some(x)
-            if x.shape().len() <= 1 && y.shape().len() == 1 =>
-        {
+    let (monad, dyad) = PartialImpl::from_legacy_inf(move |_ctx, x, y| match x {
+        Some(x) if x.shape().len() <= 1 && y.shape().len() == 1 => {
             let x = x.clone().into_elems();
             let mut y = y.clone().into_elems();
 

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -49,10 +49,7 @@ pub fn a_tilde(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
         //     .monad_rank()
         //     .ok_or(JError::NonceError)
         //     .context("can only ~ ranked verbs")?,
-        f: Arc::new(move |ctx, y| {
-            let y = Word::Noun(y.clone());
-            mu.exec(ctx, Some(&y), &y).map(Word::Noun)
-        }),
+        f: Arc::new(move |ctx, y| mu.exec(ctx, Some(y), y).map(Word::Noun)),
     });
 
     let du = u.clone();
@@ -62,11 +59,7 @@ pub fn a_tilde(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
         //     .dyad_rank()
         //     .ok_or(JError::NonceError)
         //     .context("can only ~ ranked verbs")?,
-        f: Arc::new(move |ctx, x, y| {
-            let x = Word::Noun(x.clone());
-            let y = Word::Noun(y.clone());
-            du.exec(ctx, Some(&y), &x).map(Word::Noun)
-        }),
+        f: Arc::new(move |ctx, x, y| du.exec(ctx, Some(y), x).map(Word::Noun)),
     });
 
     Ok(Word::Verb(
@@ -97,7 +90,7 @@ pub fn a_slash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
             .reduce(|y, x| {
                 let x = x?;
                 let y = y?;
-                u.exec(ctx, Some(&Word::Noun(x)), &Word::Noun(y))
+                u.exec(ctx, Some(&x), &y)
             })
             .ok_or(JError::DomainError)?
             .map(Word::Noun)
@@ -120,10 +113,10 @@ pub fn a_slash_dot(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
             let classification = v_self_classify(x).context("classify")?;
             do_atop(
                 ctx,
-                Some(&Word::Noun(classification)),
+                Some(&classification),
                 &u,
                 &primitive_verbs("#").expect("tally always exists"),
-                &Word::Noun(y.clone()),
+                y,
             )
             .map(Word::Noun)
         }
@@ -150,7 +143,7 @@ pub fn a_backslash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
             for i in 1..=y.len() {
                 let chunk = &y[..i];
                 piece.push(
-                    u.exec(ctx, None, &Word::Noun(fill_promote_list_cow(chunk)?))
+                    u.exec(ctx, None, &fill_promote_list_cow(chunk)?)
                         .context("backslash (u)")?,
                 );
             }
@@ -160,7 +153,7 @@ pub fn a_backslash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
             let x = x.approx_i64_one().context("backslash's x")?;
             let mut piece = Vec::new();
             let mut f = |chunk: &[JArrayCow]| -> Result<()> {
-                piece.push(u.exec(ctx, None, &Word::Noun(fill_promote_list_cow(chunk)?))?);
+                piece.push(u.exec(ctx, None, &fill_promote_list_cow(chunk)?)?);
                 Ok(())
             };
 
@@ -198,7 +191,7 @@ pub fn a_suffix_outfix(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
             let y = y.outer_iter().collect_vec();
             let mut piece = Vec::new();
             for i in 0..y.len() {
-                piece.push(u.exec(ctx, None, &Word::Noun(fill_promote_list_cow(&y[i..])?))?);
+                piece.push(u.exec(ctx, None, &fill_promote_list_cow(&y[i..])?)?);
             }
             JArray::from_fill_promote(piece).map(Word::Noun)
         }

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -159,9 +159,11 @@ pub fn a_slash_dot(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
 }
 
 /// (0 _)
-pub fn a_backslash(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
-    match (x, u, y) {
-        (None, Word::Verb(_, u), Word::Noun(y)) => {
+pub fn a_backslash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
+    let Word::Verb(_, u) = u else { return Err(JError::DomainError).context("backslash's u must be a verb"); };
+    let u = u.clone();
+    let (monad, dyad) = PartialImpl::from_legacy_inf(move |ctx, x, y| match x {
+        None => {
             let y = y.outer_iter().collect_vec();
             let mut piece = Vec::new();
             for i in 1..=y.len() {
@@ -173,7 +175,7 @@ pub fn a_backslash(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Resul
             }
             JArray::from_fill_promote(piece).map(Word::Noun)
         }
-        (Some(Word::Noun(x)), Word::Verb(_, u), Word::Noun(y)) => {
+        Some(x) => {
             let x = x.approx_i64_one().context("backslash's x")?;
             let mut piece = Vec::new();
             let mut f = |chunk: &[JArrayCow]| -> Result<()> {
@@ -194,8 +196,15 @@ pub fn a_backslash(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Resul
 
             JArray::from_fill_promote(piece).map(Word::Noun)
         }
-        _ => Err(JError::NonceError).with_context(|| anyhow!("{x:?} {u:?} \\ {y:?}")),
-    }
+    });
+    Ok(Word::Verb(
+        "\\?".to_string(),
+        VerbImpl::Partial(PartialImpl {
+            name: "\\?".to_string(),
+            monad,
+            dyad,
+        }),
+    ))
 }
 
 /// (_ 0 _)

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -131,10 +131,11 @@ pub fn a_slash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
     ))
 }
 
-pub fn a_slash_dot(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
+pub fn a_slash_dot(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
     let Word::Verb(_, u  ) = u.clone() else { return Err(JError::DomainError).context("/.'s u must be a verb"); };
-    match (x, y) {
-        (Some(Word::Noun(x)), Word::Noun(y)) if x.shape().len() == 1 && y.shape().len() == 1 => {
+
+    let (monad, dyad) = PartialImpl::from_legacy_inf(move |ctx, x, y| match x {
+        Some(x) if x.shape().len() <= 1 && y.shape().len() <= 1 => {
             let classification = v_self_classify(x).context("classify")?;
             do_atop(
                 ctx,
@@ -146,7 +147,15 @@ pub fn a_slash_dot(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Resul
             .map(Word::Noun)
         }
         _ => Err(JError::NonceError).with_context(|| anyhow!("{x:?} {u:?} /. {y:?}")),
-    }
+    });
+    Ok(Word::Verb(
+        "/.?".to_string(),
+        VerbImpl::Partial(PartialImpl {
+            name: "/.?".to_string(),
+            monad,
+            dyad,
+        }),
+    ))
 }
 
 /// (0 _)

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -208,9 +208,12 @@ pub fn a_backslash(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
 }
 
 /// (_ 0 _)
-pub fn a_suffix_outfix(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> Result<Word> {
-    match (x, u, y) {
-        (None, Word::Verb(_, u), Word::Noun(y)) => {
+pub fn a_suffix_outfix(_ctx: &mut Ctx, u: &Word) -> Result<Word> {
+    let Word::Verb(_, u) = u else { return Err(JError::DomainError).context("suffix outfix's u must be a verb"); };
+
+    let u = u.clone();
+    let (monad, dyad) = PartialImpl::from_legacy_inf(move |ctx, x, y| match x {
+        None => {
             let y = y.outer_iter().collect_vec();
             let mut piece = Vec::new();
             for i in 0..y.len() {
@@ -218,8 +221,17 @@ pub fn a_suffix_outfix(ctx: &mut Ctx, x: Option<&Word>, u: &Word, y: &Word) -> R
             }
             JArray::from_fill_promote(piece).map(Word::Noun)
         }
-        _ => Err(JError::NonceError).with_context(|| anyhow!("{x:?} {u:?} \\ {y:?}")),
-    }
+        _ => Err(JError::NonceError).with_context(|| anyhow!("{x:?} {u:?} \\. {y:?}")),
+    });
+
+    Ok(Word::Verb(
+        "\\.?".to_string(),
+        VerbImpl::Partial(PartialImpl {
+            name: "\\.?".to_string(),
+            monad,
+            dyad,
+        }),
+    ))
 }
 
 /// (_ _ _)

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -15,6 +15,7 @@ pub use conj::*;
 #[derive(Clone, Debug, PartialEq)]
 pub enum ModifierImpl {
     Adverb(SimpleAdverb),
+    Adverb2(SimpleAdverb2),
     Conjunction(SimpleConjunction),
     Cor,
     DerivedAdverb { l: Box<Word>, r: Box<Word> },
@@ -50,6 +51,7 @@ impl ModifierImpl {
                     "TODO: DerivedAdverb\nl: {l:?}\nr: {r:?}\nx: {x:?}\nu: {u:?}\nv: {v:?}\ny: {y:?}"
                 ),
             },
+            ModifierImpl::Adverb2(_) |
             ModifierImpl::Cor |
             ModifierImpl::Conjunction(_) => bail!("shouldn't be calling these"),
         }
@@ -60,6 +62,17 @@ impl ModifierImpl {
             ModifierImpl::Cor => c_cor(ctx, u, v)?,
             ModifierImpl::Conjunction(c) => (false, (c.f)(ctx, u, v)?),
             _ => return Err(JError::SyntaxError).context("non-conjunction in conjunction context"),
+        })
+    }
+    pub fn form_adverb(&self, ctx: &mut Ctx, u: &Word) -> Result<Option<Word>> {
+        Ok(match self {
+            ModifierImpl::Adverb(_) => None,
+            ModifierImpl::Adverb2(c) => Some((c.f)(ctx, u)?),
+            ModifierImpl::DerivedAdverb { .. } => None,
+            _ => {
+                return Err(JError::SyntaxError)
+                    .with_context(|| anyhow!("non-adverb in adverb context: {self:?}"))
+            }
         })
     }
 }

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -16,11 +16,11 @@ pub enum ModifierImpl {
     Adverb(SimpleAdverb),
     Conjunction(SimpleConjunction),
     Cor,
-    DerivedAdverb { l: Box<Word>, r: Box<Word> },
+    DerivedAdverb { c: Box<ModifierImpl>, u: Box<Word> },
 }
 
 impl ModifierImpl {
-    pub fn form(&self, ctx: &mut Ctx, u: &Word, v: &Word) -> Result<(bool, Word)> {
+    pub fn form_conjunction(&self, ctx: &mut Ctx, u: &Word, v: &Word) -> Result<(bool, Word)> {
         Ok(match self {
             ModifierImpl::Cor => c_cor(ctx, u, v)?,
             ModifierImpl::Conjunction(c) => (false, (c.f)(ctx, u, v)?),
@@ -31,7 +31,11 @@ impl ModifierImpl {
     pub fn form_adverb(&self, ctx: &mut Ctx, u: &Word) -> Result<Option<Word>> {
         Ok(match self {
             ModifierImpl::Adverb(c) => Some((c.f)(ctx, u)?),
-            ModifierImpl::DerivedAdverb { .. } => None,
+            ModifierImpl::DerivedAdverb { c, u: v } => {
+                let (farcical, word) = c.form_conjunction(ctx, u, v)?;
+                assert!(!farcical);
+                Some(word)
+            }
             _ => {
                 return Err(JError::SyntaxError)
                     .with_context(|| anyhow!("non-adverb in adverb context: {self:?}"))

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -15,7 +15,6 @@ pub use conj::*;
 #[derive(Clone, Debug, PartialEq)]
 pub enum ModifierImpl {
     Adverb(SimpleAdverb),
-    Adverb2(SimpleAdverb2),
     Conjunction(SimpleConjunction),
     Cor,
     DerivedAdverb { l: Box<Word>, r: Box<Word> },
@@ -31,9 +30,6 @@ impl ModifierImpl {
         y: &Word,
     ) -> Result<Word> {
         match self {
-            ModifierImpl::Adverb(a) => {
-                (a.f)(ctx, x, u, y).with_context(|| anyhow!("adverb: {:?}", a.name))
-            }
             ModifierImpl::DerivedAdverb { l, r } => match (l.deref(), r.deref()) {
                 // TODO: hot garbage, working around adverbs not being forming, I think?
                 // TODO: expecting DerivedAdverbs to go with forming adverbs
@@ -51,7 +47,7 @@ impl ModifierImpl {
                     "TODO: DerivedAdverb\nl: {l:?}\nr: {r:?}\nx: {x:?}\nu: {u:?}\nv: {v:?}\ny: {y:?}"
                 ),
             },
-            ModifierImpl::Adverb2(_) |
+            ModifierImpl::Adverb(_) |
             ModifierImpl::Cor |
             ModifierImpl::Conjunction(_) => bail!("shouldn't be calling these"),
         }
@@ -66,8 +62,7 @@ impl ModifierImpl {
     }
     pub fn form_adverb(&self, ctx: &mut Ctx, u: &Word) -> Result<Option<Word>> {
         Ok(match self {
-            ModifierImpl::Adverb(_) => None,
-            ModifierImpl::Adverb2(c) => Some((c.f)(ctx, u)?),
+            ModifierImpl::Adverb(c) => Some((c.f)(ctx, u)?),
             ModifierImpl::DerivedAdverb { .. } => None,
             _ => {
                 return Err(JError::SyntaxError)

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -16,6 +16,7 @@ pub enum ModifierImpl {
     Adverb(SimpleAdverb),
     Conjunction(SimpleConjunction),
     Cor,
+    // this is a partially applied conjunction
     DerivedAdverb { c: Box<ModifierImpl>, u: Box<Word> },
 }
 
@@ -28,13 +29,13 @@ impl ModifierImpl {
         })
     }
 
-    pub fn form_adverb(&self, ctx: &mut Ctx, u: &Word) -> Result<Option<Word>> {
+    pub fn form_adverb(&self, ctx: &mut Ctx, u: &Word) -> Result<Word> {
         Ok(match self {
-            ModifierImpl::Adverb(c) => Some((c.f)(ctx, u)?),
+            ModifierImpl::Adverb(c) => (c.f)(ctx, u)?,
             ModifierImpl::DerivedAdverb { c, u: v } => {
                 let (farcical, word) = c.form_conjunction(ctx, u, v)?;
                 assert!(!farcical);
-                Some(word)
+                word
             }
             _ => {
                 return Err(JError::SyntaxError)

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -205,6 +205,7 @@ impl VerbImpl {
     pub fn monad_rank(&self) -> Option<Rank> {
         match self {
             Self::Primitive(p) => Some(p.monad.rank),
+            Self::Partial(p) => p.monad.as_ref().map(|p| p.rank),
             _ => None,
         }
     }
@@ -213,6 +214,7 @@ impl VerbImpl {
     pub fn dyad_rank(&self) -> Option<DyadRank> {
         match self {
             Self::Primitive(p) => p.dyad.map(|d| d.rank),
+            Self::Partial(p) => p.dyad.as_ref().map(|d| d.rank),
             _ => None,
         }
     }

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use super::ranks::Rank;
 use crate::cells::{apply_cells, fill_promote_reshape, generate_cells, monad_apply, monad_cells};
@@ -15,11 +15,6 @@ pub enum VerbImpl {
 
     Partial(PartialImpl),
 
-    // Something to do with the internals of adverb chains
-    DerivedVerb {
-        l: Box<Word>,
-        m: Box<Word>,
-    },
     Fork {
         f: Box<Word>,
         g: Box<Word>,
@@ -142,9 +137,6 @@ impl VerbImpl {
                 }
                 other => Err(JError::DomainError)
                     .with_context(|| anyhow!("partial on non-nouns: {other:#?}")),
-            },
-            VerbImpl::DerivedVerb { l, m } => match (l.deref(), m.deref()) {
-                _ => bail!("invalid {:?}", self),
             },
             VerbImpl::Fork { f, g, h } => match (f.deref(), g.deref(), h.deref()) {
                 (Verb(_, f), Verb(_, g), Verb(_, h)) => {


### PR DESCRIPTION
 * adverbs are now "forming", they return partials.
 * derivedadverbs are now forming too; they could only ever contain a conjunction(*), and act like a partially applied conjunction
 * this removes the concept of derivedverbs(!)

I couldn't hit the Adverb Adverb matching so I have no idea what it's supposed to do, I've made it Error instead of fixing it.