### PR TITLE
feat: some space for generating names and something approaching debug output

### DIFF
--- a/src/eval/controls.rs
+++ b/src/eval/controls.rs
@@ -6,8 +6,8 @@ use itertools::Itertools;
 
 use crate::eval::eval_lines;
 use crate::modifiers::{ModifierImpl, OwnedAdverb, OwnedConjunction};
-use crate::verbs::{BivalentOwned, PartialImpl, VerbImpl};
-use crate::{arr0d, primitive_conjunctions, HasEmpty, JArray, JError, Rank, Word};
+use crate::verbs::{BivalentOwned, PartialDef, PartialImpl, VerbImpl};
+use crate::{HasEmpty, JArray, JError, Rank, Word};
 
 enum Resolution {
     Complete,
@@ -214,7 +214,7 @@ pub fn create_def(mode: char, def: Vec<Word>) -> Result<Word> {
             };
             Word::Verb(VerbImpl::Partial(PartialImpl {
                 imp,
-                def: Some(prepend_cor(3, def)),
+                def: build_cor(3, def),
             }))
         }
         'd' => {
@@ -241,7 +241,7 @@ pub fn create_def(mode: char, def: Vec<Word>) -> Result<Word> {
             };
             Word::Verb(VerbImpl::Partial(PartialImpl {
                 imp,
-                def: Some(prepend_cor(4, def)),
+                def: build_cor(4, def),
             }))
         }
         other => {
@@ -251,13 +251,8 @@ pub fn create_def(mode: char, def: Vec<Word>) -> Result<Word> {
     })
 }
 
-fn prepend_cor(i: i64, mut def: Vec<Word>) -> Vec<Word> {
-    def.insert(
-        0,
-        Word::Conjunction(primitive_conjunctions(":").expect("static name")),
-    );
-    def.insert(0, Word::Noun(JArray::from(arr0d(i))));
-    def
+fn build_cor(i: i64, def: Vec<Word>) -> Box<PartialDef> {
+    Box::new(PartialDef::Cor(i, def))
 }
 
 // TODO: this is typically called from partial_exec which has a panic

--- a/src/eval/semi.rs
+++ b/src/eval/semi.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Context, Result};
+use itertools::Itertools;
+use ndarray::IxDyn;
 
 use crate::ctx::Eval;
 use crate::verbs::VerbImpl;
@@ -78,6 +80,23 @@ fn quote_string(s: impl AsRef<str>) -> String {
     let s = s.as_ref();
     let s = s.replace('\'', "''");
     format!("'{s}'")
+}
+
+fn quote_arr(arr: &JArray) -> String {
+    let shape = if arr.shape().is_empty() {
+        String::new()
+    } else {
+        format!(
+            "{} $ ",
+            arr.shape().iter().map(|v| format!("{v}")).join(" ")
+        )
+    };
+
+    let arr = arr
+        .reshape(IxDyn(&[arr.tally()]))
+        .expect("reshape to same size is infallible");
+
+    format!("{shape}{}", format!("{arr}").trim())
 }
 
 impl MaybeVerb {

--- a/src/eval/semi.rs
+++ b/src/eval/semi.rs
@@ -54,6 +54,15 @@ impl Into<Word> for MaybeVerb {
 }
 
 impl VerbNoun {
+    pub fn name(&self) -> String {
+        use VerbNoun::*;
+        match self {
+            Verb(MaybeVerb::Verb(v)) => v.name(),
+            Verb(MaybeVerb::Name(v)) => quote_string(v),
+            Noun(arr) => quote_arr(arr),
+        }
+    }
+
     pub fn boxed_ar(&self) -> Result<JArray> {
         match self {
             VerbNoun::Verb(MaybeVerb::Verb(v)) => v.boxed_ar(),
@@ -63,6 +72,12 @@ impl VerbNoun {
             VerbNoun::Noun(n) => Word::Noun(n.clone()).boxed_ar(),
         }
     }
+}
+
+fn quote_string(s: impl AsRef<str>) -> String {
+    let s = s.as_ref();
+    let s = s.replace('\'', "''");
+    format!("'{s}'")
 }
 
 impl MaybeVerb {

--- a/src/eval/semi.rs
+++ b/src/eval/semi.rs
@@ -53,6 +53,18 @@ impl Into<Word> for MaybeVerb {
     }
 }
 
+impl VerbNoun {
+    pub fn boxed_ar(&self) -> Result<JArray> {
+        match self {
+            VerbNoun::Verb(MaybeVerb::Verb(v)) => v.boxed_ar(),
+            // TODO: don't LOOPBACK to Word
+            VerbNoun::Verb(MaybeVerb::Name(s)) => Word::Name(s.clone()).boxed_ar(),
+            // TODO: don't LOOPBACK to Word
+            VerbNoun::Noun(n) => Word::Noun(n.clone()).boxed_ar(),
+        }
+    }
+}
+
 impl MaybeVerb {
     // clones() in all cases, but without it, you can't really eval the result
     // (due to ctx being borrowed immutable, and eval needing it mutable), so clone here for easier users?

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 use ndarray::IxDyn;
 
-use crate::cells::fill_promote_list;
+use crate::cells::{fill_promote_list, fill_promote_reshape};
 use crate::eval::VerbNoun;
 use crate::modifiers::do_atop;
 use crate::number::promote_to_array;
@@ -105,7 +105,7 @@ fn a_table(ctx: &mut Ctx, u: &VerbImpl, x: &JArray, y: &JArray) -> Result<JArray
         }
     }
 
-    JArray::from_fill_promote(items)?.reshape(IxDyn(&[x.len_of_0(), y.len_of_0()]))
+    fill_promote_reshape((vec![x.len_of_0(), y.len_of_0()], items))
 }
 
 pub fn a_slash_dot(_ctx: &mut Ctx, u: &VerbNoun) -> Result<BivalentOwned> {

--- a/src/modifiers/conj.rs
+++ b/src/modifiers/conj.rs
@@ -11,7 +11,9 @@ use crate::cells::{apply_cells, fill_promote_reshape, monad_cells};
 use crate::eval::{create_def, resolve_controls, VerbNoun};
 use crate::foreign::foreign;
 use crate::scan::str_to_primitive;
-use crate::verbs::{append_nd, exec_dyad, exec_monad, BivalentOwned, PartialImpl, Rank, VerbImpl};
+use crate::verbs::{
+    append_nd, exec_dyad, exec_monad, BivalentOwned, PartialDef, PartialImpl, Rank, VerbImpl,
+};
 use crate::{arr0d, generate_cells, Ctx};
 use crate::{HasEmpty, JArray, JError, Word};
 
@@ -336,7 +338,7 @@ pub fn c_agenda(ctx: &mut Ctx, u: &Word, v: &Word) -> Result<Word> {
                     // supposedly depends on the rank of v
                     ranks: Rank::inf_inf_inf(),
                 },
-                def: None,
+                def: Box::new(PartialDef::Unimplemented("u @.")),
             })))
         }
         _ => Err(JError::DomainError).context("agenda's index type"),
@@ -555,7 +557,7 @@ pub fn c_cor_u(u: &VerbImpl, v: &Word) -> Result<Word> {
             // TODO: ranks should be from u and v, allegedly
             ranks: Rank::inf_inf_inf(),
         },
-        def: None,
+        def: Box::new(PartialDef::Unimplemented("u :")),
     })))
 }
 

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -115,6 +115,15 @@ impl ModifierImpl {
         ))
     }
 
+    pub fn name(&self) -> String {
+        use ModifierImpl::*;
+        match self {
+            Adverb(a) => a.name.to_string(),
+            Conjunction(c) => c.name.to_string(),
+            Cor => ":".to_string(),
+        }
+    }
+
     pub fn boxed_ar(&self) -> Result<JArray> {
         use ModifierImpl::*;
         Ok(match self {

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -120,7 +120,12 @@ impl ModifierImpl {
         match self {
             Adverb(a) => a.name.to_string(),
             Conjunction(c) => c.name.to_string(),
+            WordyConjunction(w) => w.name.to_string(),
+            OwnedConjunction(_c) => format!("unrepresentable conjunction"),
             Cor => ":".to_string(),
+            OwnedAdverb(_a) => format!("unrepresentable adverb"),
+            DerivedAdverb { .. } => format!("unrepresentable adverb"),
+            MmHook { .. } => format!("unrepresentable mmhook"),
         }
     }
 

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -199,6 +199,18 @@ impl VerbImpl {
         })
     }
 
+    pub fn name(&self) -> String {
+        use VerbImpl::*;
+        match self {
+            Primitive(p) => p.name.to_string(),
+            Partial(p) => p.name(),
+            Fork { .. } => {}
+            Hook { .. } => {}
+            Cap => "[:".to_string(),
+            Number(i) => format!("({i}:)"),
+        }
+    }
+
     pub fn boxed_ar(&self) -> Result<JArray> {
         // https://code.jsoftware.com/wiki/Vocabulary/Foreigns#m5
         use VerbImpl::*;

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -7,8 +7,8 @@ use super::ranks::Rank;
 use crate::cells::{apply_cells, fill_promote_reshape, generate_cells, monad_apply, monad_cells};
 use crate::number::float_is_int;
 use crate::verbs::primitive::PrimitiveImpl;
-use crate::verbs::{DyadRank, PartialImpl};
-use crate::{primitive_verbs, Ctx, JArray, JError, Num, Word};
+use crate::verbs::{DyadRank, PartialDef, PartialImpl};
+use crate::{arr0ad, primitive_verbs, Ctx, JArray, JError, Num, Word};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum VerbImpl {
@@ -210,38 +210,31 @@ impl VerbImpl {
                 Some(i) => format!("_{i}:"),
                 None => return Err(JError::NonceError).context("super lazy about infinity"),
             }),
-            Partial(PartialImpl { def, .. }) if def.is_some() => {
-                let def = def.as_ref().expect("wtb if-let in match");
-                match def.len() {
-                    // see the comment on PartialImpl's def field
-                    // adverb
-                    2 => JArray::from_list(vec![
-                        def[0].boxed_ar()?,
-                        JArray::from_list(vec![def[1].boxed_ar()?]),
-                    ]),
-                    // conj
-                    3 => JArray::from_list(vec![
-                        def[1].boxed_ar()?,
-                        JArray::from_list(vec![def[0].boxed_ar()?, def[2].boxed_ar()?]),
-                    ]),
-                    len if len > 3 => {
-                        warn!("lying about serialising a udf: {def:?}");
-                        // TODO: NOT IMPLEMENTED!!!
-                        // TODO: NOT IMPLEMENTED!!!
-                        JArray::from_list([
-                            def[1].boxed_ar()?,
-                            JArray::from_list([
-                                def[0].boxed_ar()?,
-                                Word::Noun(JArray::from_string("assert. 0")).boxed_ar()?,
-                            ]),
-                        ])
-                    }
-                    len => {
-                        return Err(JError::NonceError)
-                            .with_context(|| anyhow!("boxed_ar of {len}"))
-                    }
+            Partial(PartialImpl { def, .. }) => match &**def {
+                PartialDef::Adverb(a, u) => {
+                    JArray::from_list(vec![a.boxed_ar()?, JArray::from_list(vec![u.boxed_ar()?])])
                 }
-            }
+                PartialDef::Conjunction(u, c, v) => JArray::from_list(vec![
+                    c.boxed_ar()?,
+                    JArray::from_list(vec![u.boxed_ar()?, v.boxed_ar()?]),
+                ]),
+                PartialDef::Cor(n, def) => {
+                    warn!("lying about serialising a udf: {def:?}");
+                    // TODO: NOT IMPLEMENTED!!!
+                    // TODO: NOT IMPLEMENTED!!!
+                    JArray::from_list([
+                        JArray::from_string(":"),
+                        JArray::from_list([
+                            Word::Noun(JArray::IntArray(arr0ad(*n))).boxed_ar()?,
+                            Word::Noun(JArray::from_string("assert. 0")).boxed_ar()?,
+                        ]),
+                    ])
+                }
+                PartialDef::Unimplemented(msg) => {
+                    return Err(JError::NonceError)
+                        .with_context(|| anyhow!("unimplemented boxed_ar of Partial: {msg}"))
+                }
+            },
             Hook { l, r } => JArray::from_list([
                 JArray::from_string("2"),
                 JArray::from_list([l.boxed_ar()?, r.boxed_ar()?]),

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -121,7 +121,7 @@ impl VerbImpl {
                     Some(x) => exec_dyad_inner(|x, y| biv(ctx, Some(x), y), p.imp.ranks.1, x, y)
                         .with_context(|| anyhow!("x: {x:?}"))
                         .with_context(|| anyhow!("y: {y:?}"))
-                        .with_context(|| anyhow!("dyadic partial {:?}", p.name())),
+                        .with_context(|| anyhow!("dyadic partial: {}", p.name())),
                 }
             }
             VerbImpl::Fork { f, g, h } => match (f.deref(), g.deref(), h.deref()) {
@@ -204,8 +204,8 @@ impl VerbImpl {
         match self {
             Primitive(p) => p.name.to_string(),
             Partial(p) => p.name(),
-            Fork { .. } => {}
-            Hook { .. } => {}
+            Fork { .. } => format!("(todo fork)"),
+            Hook { .. } => format!("(todo hook)"),
             Cap => "[:".to_string(),
             Number(i) => format!("({i}:)"),
         }

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
+use crate::eval::VerbNoun;
+use crate::modifiers::ModifierImpl;
 use crate::{Ctx, JArray, JError, Word};
 
 use super::ranks::{DyadRank, Rank};
@@ -12,8 +14,15 @@ pub type BivalentOwnedF = Arc<dyn Fn(&mut Ctx, Option<&JArray>, &JArray) -> Resu
 #[derive(Clone)]
 pub struct PartialImpl {
     pub imp: BivalentOwned,
-    // This is probably an enum { adverb(a,w), conj(c,w,w) , udf(n,vec<w>) }?
-    pub def: Option<Vec<Word>>,
+    pub def: Box<PartialDef>,
+}
+
+#[derive(Clone, Debug)]
+pub enum PartialDef {
+    Adverb(ModifierImpl, VerbNoun),
+    Conjunction(VerbNoun, ModifierImpl, VerbNoun),
+    Cor(i64, Vec<Word>),
+    Unimplemented(&'static str),
 }
 
 #[derive(Clone)]
@@ -25,8 +34,6 @@ pub struct BivalentOwned {
 impl PartialImpl {
     pub fn name(&self) -> String {
         match self.def.as_ref() {
-            Some(words) if words.len() == 2 => format!("PartialImpl({:?})", words[0]),
-            Some(words) if words.len() == 3 => format!("PartialImpl({:?})", words[1]),
             _ => format!("[TODO: no name for partial {:?}]", self.def),
         }
     }

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -33,8 +33,11 @@ pub struct BivalentOwned {
 
 impl PartialImpl {
     pub fn name(&self) -> String {
-        match self.def.as_ref() {
-            _ => format!("[TODO: no name for partial {:?}]", self.def),
+        match &*self.def {
+            PartialDef::Adverb(a, u) => format!("({} {})", a.name(), u.name()),
+            PartialDef::Conjunction(u, a, v) => format!("({} {} {})", u.name(), a.name(), v.name()),
+            PartialDef::Cor(i, _def) => format!("({i} : ???)"),
+            PartialDef::Unimplemented(hint) => format!("(no display for partial {hint}"),
         }
     }
 }

--- a/src/verbs/partial.rs
+++ b/src/verbs/partial.rs
@@ -34,7 +34,7 @@ pub struct BivalentOwned {
 impl PartialImpl {
     pub fn name(&self) -> String {
         match &*self.def {
-            PartialDef::Adverb(a, u) => format!("({} {})", a.name(), u.name()),
+            PartialDef::Adverb(a, u) => format!("({} {})", u.name(), a.name()),
             PartialDef::Conjunction(u, a, v) => format!("({} {} {})", u.name(), a.name(), v.name()),
             PartialDef::Cor(i, _def) => format!("({i} : ???)"),
             PartialDef::Unimplemented(hint) => format!("(no display for partial {hint}"),


### PR DESCRIPTION
#146 but I didn't try and fix `v_append`.

Add some way to turn executable code back into displayable code, primarily for debug output? The jsoft implementation does a much better job of eliminating brackets.