### PR TITLE
feat: move everyone away from the legacy fill code and delete it

### DIFF
--- a/docs/CONVERSION.md
+++ b/docs/CONVERSION.md
@@ -58,8 +58,3 @@ JArray::from_promo_fill([
     JArray::from_list([3.5, 4.2, 5.5]),
 ])
 ```
-
-You could build `Elem`s manually, and `promote_to_array`, which probably isn't a
-great idea unless you're already operating on `Elem`s.
-
-`promote_to_array(vec![Elem::Num(Num::from(5i64))])`

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
         .ok_or_else(|| anyhow!("path must be valid utf-8"))?;
     let arg = arg.replace('\'', "''");
     let j = run_j(format!("(0!:0) <'{arg}'\n10 (6!:2) '10 comb 20'"))?;
-    let j: f64 = j.parse().with_context(|| anyhow!("j said: {j}"))?;
+    let _j: f64 = j.parse().with_context(|| anyhow!("j said: {j}"))?;
 
     Ok(())
 }

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -197,6 +197,28 @@ impl JArray {
         impl_array!(self, |a: &'s ArrayBase<_, _>| a.t().to_shared().into())
     }
 
+    /// converts a singleton list into an atom (you almost certainly do not want this),
+    /// returns the array unmodified if it is not a singleton
+    pub fn singleton_to_atom(self) -> JArray {
+        if self.shape() == [1] {
+            self.reshape(IxDyn(&[]))
+                .expect("stripping leading dimensions is okay")
+        } else {
+            self
+        }
+    }
+
+    /// converts an atom into a singleton list
+    /// returns the array unmodified if it is not an atom
+    /// see also: [`rank_extend`]
+    pub fn atom_to_singleton(self) -> JArray {
+        if self.shape().is_empty() {
+            self.rank_extend(1)
+        } else {
+            self
+        }
+    }
+
     pub fn select(&self, axis: Axis, ix: &[usize]) -> JArray {
         impl_array!(self, |a: &ArrayBase<_, _>| a
             .select(axis, ix)

--- a/src/arrays/owned.rs
+++ b/src/arrays/owned.rs
@@ -12,7 +12,7 @@ use num_traits::ToPrimitive;
 use super::nd_ext::len_of_0;
 use crate::arrays::elem::Elem;
 use crate::arrays::{display, size_of_shape_checked};
-use crate::cells::fill_promote_list;
+use crate::cells::fill_promote_reshape;
 use crate::number::Num;
 use crate::{arr0ad, IntoVec, JError};
 
@@ -560,7 +560,8 @@ impl JArray {
     /// );
     /// ```
     pub fn from_fill_promote(items: impl IntoIterator<Item = JArray>) -> Result<JArray> {
-        fill_promote_list(items)
+        let vec = items.into_iter().collect_vec();
+        fill_promote_reshape((vec![vec.len()], vec))
     }
 
     /// Produce a 1D char array from a Rust String-like

--- a/src/cells/flatten.rs
+++ b/src/cells/flatten.rs
@@ -11,12 +11,6 @@ use crate::number::{infer_kind_from_boxes, Num, Promote};
 use crate::verbs::VerbResult;
 use crate::{map_kind, Elem, JArray, JError};
 
-/// See [`JArray::from_fill_promote`].
-pub fn fill_promote_list(items: impl IntoIterator<Item = JArray>) -> Result<JArray> {
-    let vec = items.into_iter().collect_vec();
-    fill_promote_reshape((vec![vec.len()], vec))
-}
-
 // concat_promo_fill(&[JArrayCow]) -> JArray
 // concat_promo_fill(x).shape()[0] == x.len()
 // fn flatten_reshaping(prefix: Shape, l: &[JArrayCow]) {

--- a/src/cells/mod.rs
+++ b/src/cells/mod.rs
@@ -1,5 +1,5 @@
 mod flatten;
 mod gen_apply;
 
-pub use flatten::{fill_promote_list, fill_promote_reshape};
+pub use flatten::fill_promote_reshape;
 pub use gen_apply::{apply_cells, generate_cells, monad_apply, monad_cells};

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use crate::cells::{fill_promote_list, fill_promote_reshape};
 use crate::eval::VerbNoun;
 use crate::modifiers::do_atop;
-use crate::number::promote_to_array;
 use crate::verbs::{v_self_classify, BivalentOwned, VerbImpl};
 use crate::{primitive_verbs, Ctx, JArray, JError, Rank};
 

--- a/src/modifiers/adverb.rs
+++ b/src/modifiers/adverb.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use anyhow::{anyhow, Context, Result};
 use itertools::Itertools;
 
-use crate::cells::{fill_promote_list, fill_promote_reshape};
+use crate::cells::fill_promote_reshape;
 use crate::eval::VerbNoun;
 use crate::modifiers::do_atop;
 use crate::verbs::{v_self_classify, BivalentOwned, VerbImpl};
@@ -142,8 +142,12 @@ pub fn a_backslash(_ctx: &mut Ctx, u: &VerbNoun) -> Result<BivalentOwned> {
             for i in 1..=y.len() {
                 let chunk = &y[..i];
                 piece.push(
-                    u.exec(ctx, None, &fill_promote_list(chunk.iter().cloned())?)
-                        .context("backslash (u)")?,
+                    u.exec(
+                        ctx,
+                        None,
+                        &JArray::from_fill_promote(chunk.iter().cloned())?,
+                    )
+                    .context("backslash (u)")?,
                 );
             }
             JArray::from_fill_promote(piece)
@@ -152,7 +156,11 @@ pub fn a_backslash(_ctx: &mut Ctx, u: &VerbNoun) -> Result<BivalentOwned> {
             let x = x.approx_i64_one().context("backslash's x")?;
             let mut piece = Vec::new();
             let mut f = |chunk: &[JArray]| -> Result<()> {
-                piece.push(u.exec(ctx, None, &fill_promote_list(chunk.iter().cloned())?)?);
+                piece.push(u.exec(
+                    ctx,
+                    None,
+                    &JArray::from_fill_promote(chunk.iter().cloned())?,
+                )?);
                 Ok(())
             };
 
@@ -187,7 +195,11 @@ pub fn a_suffix_outfix(_ctx: &mut Ctx, u: &VerbNoun) -> Result<BivalentOwned> {
             let y = y.outer_iter().collect_vec();
             let mut piece = Vec::new();
             for i in 0..y.len() {
-                piece.push(u.exec(ctx, None, &fill_promote_list(y[i..].iter().cloned())?)?);
+                piece.push(u.exec(
+                    ctx,
+                    None,
+                    &JArray::from_fill_promote(y[i..].iter().cloned())?,
+                )?);
             }
             JArray::from_fill_promote(piece)
         }
@@ -243,7 +255,7 @@ fn build_curlrt(u: &JArray) -> Result<BivalentOwned> {
                     .context("index out of bounds")? = x[i % x.len()].clone();
             }
 
-            fill_promote_list(y)
+            JArray::from_fill_promote(y)
         }
         None => Err(JError::NonceError).context("monadic }"),
     });

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -2,6 +2,4 @@ mod number;
 mod promote;
 
 pub use number::{float_is_int, Num};
-pub use promote::{
-    elems_to_jarray, infer_kind_from_boxes, infer_kind_from_elems, promote_to_array, Promote,
-};
+pub use promote::{infer_kind_from_boxes, Promote};

--- a/src/number/promote.rs
+++ b/src/number/promote.rs
@@ -1,43 +1,11 @@
-use anyhow::{anyhow, Context, Result};
 use std::fmt;
 
-use ndarray::prelude::*;
 use num::complex::Complex64;
 use num::rational::BigRational;
 use num::BigInt;
-use num_traits::Zero;
 
 use super::Num;
 use crate::arrays::{Elem, JArray, JArrayKind};
-use crate::error::JError;
-
-#[deprecated = "use infer_kind_from_boxes via. fill_promote_list"]
-pub fn infer_kind_from_elems(parts: &[Elem]) -> JArrayKind {
-    // priority table: https://code.jsoftware.com/wiki/Vocabulary/NumericPrecisions#Numeric_Precisions_in_J
-    if parts.iter().any(|n| matches!(n, Elem::Boxed(_))) {
-        JArrayKind::Box
-    } else if parts.iter().any(|n| matches!(n, Elem::Char(_))) {
-        JArrayKind::Char
-    } else if parts
-        .iter()
-        .any(|n| matches!(n, Elem::Num(Num::Complex(_))))
-    {
-        JArrayKind::Complex
-    } else if parts.iter().any(|n| matches!(n, Elem::Num(Num::Float(_)))) {
-        JArrayKind::Float
-    } else if parts
-        .iter()
-        .any(|n| matches!(n, Elem::Num(Num::Rational(_))))
-    {
-        JArrayKind::Rational
-    } else if parts.iter().any(|n| matches!(n, Elem::Num(Num::ExtInt(_)))) {
-        JArrayKind::ExtInt
-    } else if parts.iter().any(|n| matches!(n, Elem::Num(Num::Int(_)))) {
-        JArrayKind::Int
-    } else {
-        JArrayKind::Bool
-    }
-}
 
 pub fn infer_kind_from_boxes(parts: &[JArray]) -> JArrayKind {
     // priority table: https://code.jsoftware.com/wiki/Vocabulary/NumericPrecisions#Numeric_Precisions_in_J
@@ -58,107 +26,6 @@ pub fn infer_kind_from_boxes(parts: &[JArray]) -> JArrayKind {
     } else {
         JArrayKind::Bool
     }
-}
-
-#[deprecated = "believed to be less efficient than fill_promote_list"]
-pub fn promote_to_array(parts: Vec<Elem>) -> Result<JArray> {
-    let kind = infer_kind_from_elems(&parts);
-    elems_to_jarray(kind, parts)
-}
-
-/// panics if the kind isn't directly from [`infer_kind_from_elems`].
-#[deprecated = "believed to be less efficient than fill_promote_list"]
-pub fn elems_to_jarray(kind: JArrayKind, parts: Vec<Elem>) -> Result<JArray> {
-    // priority table: https://code.jsoftware.com/wiki/Vocabulary/NumericPrecisions#Numeric_Precisions_in_J
-    match kind {
-        JArrayKind::Box => arrayise(parts.into_iter().map(|v| match v {
-            Elem::Boxed(b) => Ok(b),
-            Elem::Num(n) => Ok(n.into()),
-            other => Err(JError::NonceError).with_context(|| {
-                anyhow!("TODO: unable to arrayise partially boxed content: {other:?}")
-            }),
-        })),
-        JArrayKind::Char => arrayise(parts.into_iter().map(|v| match v {
-            Elem::Char(c) => Ok(c),
-            // we get here 'cos fill fills us with zeros, instead of with spaces, as it doesn't know?
-            Elem::Num(n) if n.is_zero() => Ok(' '),
-            other => Err(JError::NonceError).with_context(|| {
-                anyhow!("TODO: unable to arrayise partially char content: {other:?}")
-            }),
-        })),
-        JArrayKind::Complex => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(i) => i,
-                other => Complex64::new(other.approx_f64().expect("covered above"), 0.),
-            })
-        })),
-        JArrayKind::Float => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(_) => unreachable!("covered by above cases"),
-                Num::Float(i) => i,
-                other => other.approx_f64().expect("covered above"),
-            })
-        })),
-        JArrayKind::Rational => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(_) | Num::Float(_) => unreachable!("checked by infer"),
-                Num::Rational(i) => i,
-                Num::ExtInt(i) => BigRational::new(i, 1.into()),
-                Num::Int(i) => BigRational::new(i.into(), 1.into()),
-                Num::Bool(i) => BigRational::new(i.into(), 1.into()),
-            })
-        })),
-        JArrayKind::ExtInt => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(_) | Num::Float(_) | Num::Rational(_) => {
-                    unreachable!("checked by infer")
-                }
-                Num::ExtInt(i) => i,
-                Num::Int(i) => i.into(),
-                Num::Bool(i) => i.into(),
-            })
-        })),
-        JArrayKind::Int => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(_) | Num::Float(_) | Num::Rational(_) | Num::ExtInt(_) => {
-                    unreachable!("checked by infer")
-                }
-                Num::Int(i) => i,
-                Num::Bool(i) => i.into(),
-            })
-        })),
-        JArrayKind::Bool => arrayise(parts.into_iter().map(|v| {
-            let Elem::Num(v) = v else { unreachable!("checked by infer") };
-            Ok(match v {
-                Num::Complex(_)
-                | Num::Float(_)
-                | Num::Rational(_)
-                | Num::ExtInt(_)
-                | Num::Int(_) => unreachable!("checked by infer"),
-                Num::Bool(i) => i,
-            })
-        })),
-    }
-}
-
-#[inline]
-fn arrayise<T>(it: impl IntoIterator<Item = Result<T>>) -> Result<JArray>
-where
-    T: Clone,
-    JArray: From<ArrayD<T>>,
-{
-    let vec = it.into_iter().collect::<Result<Vec<T>>>()?;
-    Ok(if vec.len() == 1 {
-        ArrayD::from_elem(IxDyn(&[]), vec.into_iter().next().expect("checked length"))
-    } else {
-        ArrayD::from_shape_vec(IxDyn(&[vec.len()]), vec).expect("simple shape")
-    }
-    .into())
 }
 
 pub trait Promote: Clone + fmt::Debug {

--- a/src/scan/litnum.rs
+++ b/src/scan/litnum.rs
@@ -42,9 +42,12 @@ pub fn scan_litnumarray(sentence: &str) -> Result<(usize, Word)> {
     let parts = parts
         .into_iter()
         .map(|(_term, num)| Elem::Num(num))
-        .collect();
+        .map(JArray::from);
 
-    Ok((l, Word::Noun(promote_to_array(parts)?)))
+    Ok((
+        l,
+        Word::Noun(JArray::from_fill_promote(parts)?.singleton_to_atom()),
+    ))
 }
 
 pub fn scan_num_token(term: &str) -> Result<Num> {

--- a/src/scan/litnum.rs
+++ b/src/scan/litnum.rs
@@ -5,8 +5,9 @@ use itertools::Itertools;
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
+use crate::cells::{fill_promote_list, fill_promote_reshape};
 use crate::number::{promote_to_array, Num};
-use crate::{Elem, JError, Word};
+use crate::{Elem, JArray, JError, Word};
 
 pub fn scan_litnumarray(sentence: &str) -> Result<(usize, Word)> {
     assert!(!sentence.contains('\n'));

--- a/src/scan/litnum.rs
+++ b/src/scan/litnum.rs
@@ -5,8 +5,7 @@ use itertools::Itertools;
 use num::complex::Complex64;
 use num::{BigInt, BigRational};
 
-use crate::cells::{fill_promote_list, fill_promote_reshape};
-use crate::number::{promote_to_array, Num};
+use crate::number::Num;
 use crate::{Elem, JArray, JError, Word};
 
 pub fn scan_litnumarray(sentence: &str) -> Result<(usize, Word)> {
@@ -38,7 +37,7 @@ pub fn scan_litnumarray(sentence: &str) -> Result<(usize, Word)> {
         })?;
     let l = term.as_ptr() as usize - sentence.as_ptr() as usize + term.len() - 1;
 
-    // promote_to_array wants the input to be Elem-wrapped
+    // from_fill_promote wants the input to be JArray-wrapped
     let parts = parts
         .into_iter()
         .map(|(_term, num)| Elem::Num(num))

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -1,7 +1,6 @@
 use std::ops::Deref;
 
 use anyhow::{anyhow, bail, Context, Result};
-use log::warn;
 
 use super::ranks::Rank;
 use crate::cells::{apply_cells, fill_promote_reshape, generate_cells, monad_apply, monad_cells};
@@ -230,16 +229,14 @@ impl VerbImpl {
                     c.boxed_ar()?,
                     JArray::from_list(vec![u.boxed_ar()?, v.boxed_ar()?]),
                 ]),
-                PartialDef::Cor(n, def) => {
+                PartialDef::Cor(n, def) => JArray::from_list([
+                    JArray::from_string(":"),
                     JArray::from_list([
-                        JArray::from_string(":"),
-                        JArray::from_list([
-                            Word::Noun(JArray::IntArray(arr0ad(*n))).boxed_ar()?,
-                            Word::Noun(JArray::from_string(stringify(def)?).rank_extend(2))
-                                .boxed_ar()?,
-                        ]),
-                    ])
-                }
+                        Word::Noun(JArray::IntArray(arr0ad(*n))).boxed_ar()?,
+                        Word::Noun(JArray::from_string(stringify(def)?).rank_extend(2))
+                            .boxed_ar()?,
+                    ]),
+                ]),
             },
             Hook { l, r } => JArray::from_list([
                 JArray::from_string("2"),

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -124,14 +124,8 @@ pub fn v_append(x: &JArray, y: &JArray) -> Result<JArray> {
             .with_context(|| anyhow!("can only append atoms or lists, not {x:?} {y:?}"));
     }
 
-    // TODO: jsoft rejects (DomainError) a bunch of cases promote_to_array accepts
-    promote_to_array(
-        x.clone()
-            .into_elems()
-            .into_iter()
-            .chain(y.clone().into_elems().into_iter())
-            .collect(),
-    )
+    // TODO: jsoft rejects (DomainError) a bunch of cases from_fill_promote accepts
+    JArray::from_fill_promote(x.outer_iter().chain(y.outer_iter()))
 }
 
 /// ,. (dyad)

--- a/src/verbs/impl_shape.rs
+++ b/src/verbs/impl_shape.rs
@@ -11,7 +11,7 @@ use ndarray::prelude::*;
 use ndarray::{concatenate, Axis, Slice};
 
 use crate::arrays::{len_of_0, ArcArrayD, IntoVec};
-use crate::number::{promote_to_array, Num};
+use crate::number::Num;
 use crate::{arr0ad, impl_array, impl_homo, JArray, JError};
 
 pub fn reshape<T>(x: &[i64], y: &ArcArrayD<T>) -> Result<ArcArrayD<T>>

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -286,12 +286,11 @@ pub fn v_sort_up(x: &JArray, y: &JArray) -> Result<JArray> {
         return Err(JError::IndexError).context("need more xs than ys");
     }
     // TODO: unnecessary clones, as usual
-    Ok(promote_to_array(
+    JArray::from_fill_promote(
         y.into_iter()
             .map(|(i, _)| i)
-            .map(|i| x[i].clone())
-            .collect(),
-    )?)
+            .map(|i| JArray::from(x[i].clone())),
+    )
 }
 
 /// \: (monad)
@@ -313,13 +312,12 @@ pub fn v_sort_down(x: &JArray, y: &JArray) -> Result<JArray> {
         return Err(JError::IndexError).context("need more xs than ys");
     }
     // TODO: unnecessary clones, as usual
-    Ok(promote_to_array(
+    JArray::from_fill_promote(
         y.into_iter()
             .rev()
             .map(|(i, _)| i)
-            .map(|i| x[i].clone())
-            .collect(),
-    )?)
+            .map(|i| JArray::from(x[i].clone())),
+    )
 }
 
 /// \[ (monad) and ] (monad) apparently

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -530,12 +530,12 @@ pub fn v_member_interval(x: &JArray, y: &JArray) -> Result<JArray> {
     let x = x.clone().into_elems();
     let y = y.clone().into_elems();
     ensure!(!x.is_empty());
-    promote_to_array(
+    Ok(JArray::from_list(
         y.windows(x.len())
-            .map(|win| Elem::Num(Num::bool(x == win)))
-            .chain(repeat(Elem::Num(Num::bool(false))).take(x.len() - 1))
-            .collect(),
-    )
+            .map(|win| (x == win) as u8)
+            .chain(repeat(0u8).take(x.len() - 1))
+            .collect_vec(),
+    ))
 }
 
 /// L. (monad) (_)

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -32,7 +32,6 @@ pub use impl_impl::*;
 pub use impl_maths::*;
 pub use impl_shape::*;
 
-use crate::cells::fill_promote_list;
 pub use partial::*;
 pub use primitive::*;
 
@@ -85,7 +84,7 @@ pub fn v_less(x: &JArray, y: &JArray) -> Result<JArray> {
         return Err(JError::NonceError).context("only available for lists");
     }
     let y = y.outer_iter().collect_vec();
-    fill_promote_list(x.outer_iter().filter(|x| !y.contains(x)))
+    JArray::from_fill_promote(x.outer_iter().filter(|x| !y.contains(x)))
 }
 
 /// -: (dyad)

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -192,14 +192,14 @@ pub fn v_raze(y: &JArray) -> Result<JArray> {
             }
         }
         JArray::BoxArray(arr) if arr.shape().len() == 1 => {
-            let mut parts = Vec::new();
+            let mut parts = Vec::with_capacity(arr.len() * 2);
             for arr in arr {
                 if arr.shape().len() > 1 {
                     return Err(JError::NonceError).context("non-list inside a box");
                 }
-                parts.extend(arr.clone().into_elems());
+                parts.extend(arr.outer_iter());
             }
-            let arr = promote_to_array(parts)?;
+            let arr = JArray::from_fill_promote(parts)?;
             // hee hee hee, unatoming
             Ok(if !arr.shape().is_empty() {
                 arr

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -9,7 +9,7 @@ mod ranks;
 use std::collections::VecDeque;
 use std::iter::repeat;
 
-use crate::number::{promote_to_array, Num};
+use crate::number::Num;
 use crate::{
     arr0ad, arr0d, impl_array, scan_with_locations, ArcArrayD, Ctx, Elem, HasEmpty, JArray, JError,
     Word,

--- a/src/verbs/mod.rs
+++ b/src/verbs/mod.rs
@@ -199,13 +199,7 @@ pub fn v_raze(y: &JArray) -> Result<JArray> {
                 }
                 parts.extend(arr.outer_iter());
             }
-            let arr = JArray::from_fill_promote(parts)?;
-            // hee hee hee, unatoming
-            Ok(if !arr.shape().is_empty() {
-                arr
-            } else {
-                arr.reshape(IxDyn(&[1usize])).context("promoted reshape")?
-            })
+            JArray::from_fill_promote(parts)
         }
         _ => Err(JError::NonceError).with_context(|| anyhow!("{y:?}")),
     }
@@ -429,13 +423,18 @@ pub fn v_numbers(x: &JArray, y: &JArray) -> Result<JArray> {
     let mut nums = Vec::new();
     for row in rows {
         let gap = width - row.len();
-        nums.extend(row.into_iter().map(Num::demote).map(Elem::Num));
+        nums.extend(
+            row.into_iter()
+                .map(Num::demote)
+                .map(Elem::Num)
+                .map(JArray::from),
+        );
         for _ in 0..gap {
-            nums.push(Elem::Num(x.clone()));
+            nums.push(JArray::from(Elem::Num(x.clone())));
         }
     }
 
-    promote_to_array(nums)
+    JArray::from_fill_promote(nums)
 }
 
 /// ": (monad)

--- a/tests/smoke.ijs
+++ b/tests/smoke.ijs
@@ -331,6 +331,9 @@ NB. rank
 NB. amend
 'x' 0 3} 'cross'
 'gw' 0 3} 'cross'
+'ABCD' 0 2 4 6} 'abcdefghijklmnop'
+'*' 0 2 4 6} 'abcdefghijklmnop'
+NB. weird ass fill rules: '*' 2} (_4 ]\ 'abcdefghijklmnop')
 
 NB. amend (legacy definition: curlyrtu)
 2 (>./)} 0 1 2

--- a/tests/smoke.toml
+++ b/tests/smoke.toml
@@ -152,6 +152,30 @@ output = '''
 encoded = 'e3,08,03,01,03,000000000000004,000000000000084,000000000000104'
 
 [[runs]]
+expr = "'*' 0 2 4 6} 'abcdefghijklmnop'"
+output = '''
+*b*d*f*hijklmnop
+'''
+encoded = 'e3,02,1,01,1,2a622a642a662a68,696a6b6c6d6e6f7,'
+
+[[runs]]
+expr = ''''*' 2} (_4 ]\ 'abcdefghijklmnop')'''
+output = '''
+abcd
+efgh
+****
+mnop
+'''
+encoded = 'e3,02,1,02,04,04,6162636465666768,2a2a2a2a6d6e6f7,'
+
+[[runs]]
+expr = "'ABCD' 0 2 4 6} 'abcdefghijklmnop'"
+output = '''
+AbBdCfDhijklmnop
+'''
+encoded = 'e3,02,1,01,1,4162426443664468,696a6b6c6d6e6f7,'
+
+[[runs]]
 expr = ''''ABCXYZ' i. (3 4 $ 'AYBXCZQAYBCA')'''
 output = '''
 0 4 1 3


### PR DESCRIPTION
Finish moving people off `promote_to_array` onto `from_fill_promote` which should do roughly the same things, but the latter is probably more efficient. They probably aren't the same around atoms and type conversions, but none of the current tests seem to care.