### PR TITLE
fix: display verb names

### DIFF
--- a/src/arrays/word.rs
+++ b/src/arrays/word.rs
@@ -141,6 +141,9 @@ impl Word {
                 c.as_ref().map(|s| s.as_str()).unwrap_or(""),
                 stringify(block)
             ),
+            IfBlock(block) => format!("if. {} end.", stringify(block)),
+            SelectBlock(block) => format!("select. {} end.", stringify(block)),
+            Case => "case.".to_string(),
             Do => "do.".to_string(),
             NewLine => "\n".to_string(),
             IsLocal => "=.".to_string(),

--- a/src/arrays/word.rs
+++ b/src/arrays/word.rs
@@ -99,12 +99,9 @@ impl fmt::Display for Word {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Word::Noun(a) => write!(f, "{}", a),
-            Word::Verb(v) => match v.token() {
-                Some(t) => write!(f, "{}", t),
-                None => write!(f, "(unrepresentable but valid verb)"),
-            },
-            Word::Adverb(_) => write!(f, "(unrepresentable but valid adverb)"),
-            Word::Conjunction(_) => write!(f, "(unrepresentable but valid conjunction)"),
+            Word::Verb(v) => write!(f, "{}", v.name()),
+            Word::Adverb(a) => write!(f, "{}", a.name()),
+            Word::Conjunction(c) => write!(f, "{}", c.name()),
             Word::Nothing => Ok(()),
             //_ => write!(f, "{:+}", self),
             _ => write!(f, "XXX TODO: unable to Display Word::{:?}", self),

--- a/src/arrays/word.rs
+++ b/src/arrays/word.rs
@@ -136,8 +136,15 @@ impl Word {
             Noun(arr) => quote_arr(arr),
             Adverb(v) => v.name(),
             Conjunction(v) => v.name(),
+            WhileBlock(b, block) => {
+                if *b {
+                    format!("whilst. {} end.", stringify(block))
+                } else {
+                    format!("while. {} end.", stringify(block))
+                }
+            }
             ForBlock(c, block) => format!(
-                "for{}. {} end.",
+                "for_{}. {} end.",
                 c.as_ref().map(|s| s.as_str()).unwrap_or(""),
                 stringify(block)
             ),
@@ -145,6 +152,10 @@ impl Word {
             SelectBlock(block) => format!("select. {} end.", stringify(block)),
             Case => "case.".to_string(),
             Do => "do.".to_string(),
+            Else => "else.".to_string(),
+            ElseIf => "elseif.".to_string(),
+            End => "end.".to_string(),
+            Return => "return.".to_string(),
             NewLine => "\n".to_string(),
             IsLocal => "=.".to_string(),
             IsGlobal => "=:".to_string(),

--- a/src/eval/semi.rs
+++ b/src/eval/semi.rs
@@ -84,7 +84,7 @@ fn quote_string(s: impl AsRef<str>) -> String {
 }
 
 pub fn quote_arr(arr: &JArray) -> String {
-    let shape = if arr.shape().is_empty() {
+    let _shape = if arr.shape().is_empty() {
         String::new()
     } else {
         format!(
@@ -97,7 +97,9 @@ pub fn quote_arr(arr: &JArray) -> String {
         .reshape(IxDyn(&[arr.tally()]))
         .expect("reshape to same size is infallible");
 
-    format!("{shape}{}", format!("{arr}").trim())
+    // format!("{shape}{}", format!("{arr}").trim())
+    // AA 20230305 Why did we want the shape included here?
+    format!("{arr}").trim().to_string()
 }
 
 impl MaybeVerb {

--- a/src/verbs/impl_impl.rs
+++ b/src/verbs/impl_impl.rs
@@ -201,12 +201,16 @@ impl VerbImpl {
         match self {
             Primitive(p) => p.name.to_string(),
             Partial(p) => p.name(),
-            // TODO: completely missing here
             Fork { f, g, h } => format!("({} {} {})", f.name(), g.name(), h.name()),
-            Hook { .. } => format!("(todo hook)"),
+            Hook { l, r } => format!("({} {})", l.name(), r.name()),
             Cap => "[:".to_string(),
-            // TODO: negatives here
-            Number(i) => format!("({i}:)"),
+            Number(i) => {
+                if i < &0.0 {
+                    format!("(_{}:)", i.abs())
+                } else {
+                    format!("({i}:)")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
```
aaron@Aarons-Air jr % cargo run
   Compiling jr v0.1.0 (/Users/aaron/codebases/jr)
    Finished dev [unoptimized + debuginfo] target(s) in 1.50s
     Running `target/debug/jr`
jr 0.1.0
   f=: 3 : 0
NB. comment
2 * y
)
(3 : '
 2 * y 
 ')
   f
(3 : '
 2 * y 
 ')
   
```

TODO: Carry a sourcefile and line number reference in (or for?) each `Word::Verb()` instance to allow Word::fmt::Display to show original source including comments when necessary. (repl log would likely be a virtual file...)