### PR TITLE
feat: 4!:3 script names foreign

### DIFF
--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -5,6 +5,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::eval::Qs;
 use crate::JError;
+use std::collections::HashMap;
 
 // :)
 pub use locales::Eval;
@@ -15,6 +16,7 @@ pub use locales::Names;
 pub struct Ctx {
     eval: Eval,
     pub input_buffers: Option<InputBuffers>,
+    pub scripts: HashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -37,6 +39,7 @@ impl Ctx {
                 suspension: None,
                 other_input_buffer: String::new(),
             }),
+            scripts: HashMap::new(),
         }
     }
 

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -5,7 +5,6 @@ use std::ops::{Deref, DerefMut};
 
 use crate::eval::Qs;
 use crate::JError;
-use std::collections::HashMap;
 
 // :)
 pub use locales::Eval;
@@ -16,7 +15,7 @@ pub use locales::Names;
 pub struct Ctx {
     eval: Eval,
     pub input_buffers: Option<InputBuffers>,
-    pub scripts: HashMap<String, String>,
+    pub scripts: Vec<(String, String)>,
 }
 
 #[derive(Debug)]
@@ -39,7 +38,7 @@ impl Ctx {
                 suspension: None,
                 other_input_buffer: String::new(),
             }),
-            scripts: HashMap::new(),
+            scripts: Vec::new(),
         }
     }
 

--- a/src/foreign/mod.rs
+++ b/src/foreign/mod.rs
@@ -109,7 +109,10 @@ pub fn foreign(l: i64, r: i64) -> Result<BivalentOwned> {
             iii,
             BivalentOwned::from_bivalent(|ctx, x, y| f_name_namelist(ctx, x, y)),
         ),
-        (4, 3) => unimplemented("list loaded scripts"),
+        (4, 3) => (
+            iii,
+            BivalentOwned::from_monad(|ctx, y| f_script_names(ctx, y)),
+        ),
         (4, 4) => unimplemented("find loaded script"),
         (4, 5) => unimplemented("name change tracing"),
         (4, 6) => unimplemented("set current script name"),

--- a/src/foreign/scripts.rs
+++ b/src/foreign/scripts.rs
@@ -39,7 +39,7 @@ pub fn f_load_script(ctx: &mut Ctx, k: i64, y: &JArray) -> Result<JArray> {
     let path = noun_to_fs_path(y)?;
     let script = fs::read_to_string(&path).with_context(|| anyhow!("reading {path:?}"))?;
     ctx.scripts
-        .insert(path.display().to_string(), script.clone());
+        .push((path.display().to_string(), script.clone()));
 
     let mut last = EvalOutput::Regular(Word::Nothing);
     for (off, line) in script.split('\n').enumerate() {
@@ -63,7 +63,11 @@ pub fn f_script_names(ctx: &mut Ctx, y: &JArray) -> Result<JArray> {
     if !y.is_empty() {
         Err(JError::RankError).context("from noun")
     } else {
-        let script_names: Vec<JArray> = ctx.scripts.keys().map(JArray::from_string).collect();
+        let script_names: Vec<JArray> = ctx
+            .scripts
+            .iter()
+            .map(|(s, _)| JArray::from_string(s))
+            .collect();
         Ok(JArray::from_list(script_names))
     }
 }


### PR DESCRIPTION
Script names and file contents are carried in the Ctx. File contents are kept so we can render original verb/conj/adv definitions eventually.